### PR TITLE
Use DateTimeOffset for folder creation timestamps

### DIFF
--- a/src/BoardMgmt.Application/Folders/Commands/CreateFolder/CreateFolderCommandHandler.cs
+++ b/src/BoardMgmt.Application/Folders/Commands/CreateFolder/CreateFolderCommandHandler.cs
@@ -29,7 +29,7 @@ public sealed class CreateFolderCommandHandler : IRequestHandler<CreateFolderCom
         {
             Name = name,
             Slug = slug,
-            CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTimeOffset.UtcNow
         };
 
         _db.Folders.Add(folder);

--- a/src/BoardMgmt.Infrastructure/Persistence/DbSeeder.cs
+++ b/src/BoardMgmt.Infrastructure/Persistence/DbSeeder.cs
@@ -122,7 +122,7 @@ public static class DbSeeder
                 Id = rootId,
                 Name = "Root",
                 Slug = "root",
-                CreatedAt = DateTime.UtcNow
+                CreatedAt = DateTimeOffset.UtcNow
             });
 
             logger.LogInformation("Seeded Root folder (Slug='root').");


### PR DESCRIPTION
## Summary
- align folder creation logic with DateTimeOffset-based audit fields in command handler
- update database seeder to record root folder timestamps with DateTimeOffset

## Testing
- not run (dotnet test not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e632ddefe08320bdf63841e9a886af