### PR TITLE
Fix auditing to use current user in AppDbContext

### DIFF
--- a/src/BoardMgmt.Infrastructure/DependencyInjection.cs
+++ b/src/BoardMgmt.Infrastructure/DependencyInjection.cs
@@ -107,6 +107,12 @@ namespace BoardMgmt.Infrastructure
             // Current user accessor
             services.AddHttpContextAccessor();
             services.AddScoped<ICurrentUser, CurrentUser>();
+            services.AddScoped<Func<ICurrentUser?>>(
+                sp =>
+                {
+                    var serviceProvider = sp;
+                    return () => serviceProvider.GetService<ICurrentUser>();
+                });
 
             // ONE PermissionService per scope, exposed via both interfaces
             services.AddScoped<IPermissionService, PermissionService>();


### PR DESCRIPTION
## Summary
- register a scoped factory that resolves the current user for the DbContext
- ensure SaveChanges can populate CreatedBy/UpdatedBy auditing fields when a user is present

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e635f3a6bc8320b53b9922e8db208e