### PR TITLE
Fix attendee removal during meeting updates

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/UpdateMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/UpdateMeetingHandler.cs
@@ -36,6 +36,7 @@ public class UpdateMeetingHandler : IRequestHandler<UpdateMeetingCommand, bool>
         if (request.AttendeesRich is not null)
         {
             var existingById = entity.Attendees.ToDictionary(a => a.Id, a => a);
+            var originalIds = existingById.Keys.ToHashSet();
 
             foreach (var dto in request.AttendeesRich)
             {
@@ -66,7 +67,9 @@ public class UpdateMeetingHandler : IRequestHandler<UpdateMeetingCommand, bool>
 
             // remove those not present in incoming list (compare by existing ids only)
             var keepIds = request.AttendeesRich.Where(a => a.Id.HasValue).Select(a => a.Id!.Value).ToHashSet();
-            var toRemove = entity.Attendees.Where(a => !keepIds.Contains(a.Id)).ToList();
+            var toRemove = entity.Attendees
+                .Where(a => originalIds.Contains(a.Id) && !keepIds.Contains(a.Id))
+                .ToList();
             foreach (var r in toRemove)
             {
                 entity.Attendees.Remove(r);


### PR DESCRIPTION
## Summary
- ensure meeting attendee updates preserve newly added attendees
- only remove attendees that were present prior to the update request

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e644da351c8320b7200ff8b5402313