### PR TITLE
Fix Microsoft 365 calendar update concurrency conflict

### DIFF
--- a/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
+++ b/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
@@ -70,7 +70,10 @@ public sealed class Microsoft365CalendarService : ICalendarService
             : m.ExternalCalendarMailbox;
 
         await _graph.Users[mailbox].Events[m.ExternalEventId]
-            .PatchAsync(patch, cancellationToken: ct);
+            .PatchAsync(
+                patch,
+                requestConfiguration => requestConfiguration.Headers.Add("If-Match", "*"),
+                cancellationToken: ct);
 
         var refreshed = await _graph.Users[mailbox].Events[m.ExternalEventId]
             .GetAsync(cancellationToken: ct);


### PR DESCRIPTION
## Summary
- ensure Microsoft 365 calendar event updates send the If-Match override header
- prevent Microsoft Graph concurrency conflicts when updating meetings

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6470bf6348320b2cacb297f385287