### PR TITLE
Fix attendee lookup variable initialization

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/UpdateMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/UpdateMeetingHandler.cs
@@ -56,7 +56,10 @@ public class UpdateMeetingHandler : IRequestHandler<UpdateMeetingCommand, bool>
             foreach (var dto in request.AttendeesRich)
             {
                 var userKey = dto.UserId?.Trim();
-                var hasUser = userKey is not null && userKey.Length > 0 && usersById.TryGetValue(userKey, out var user);
+                AppUser? user = null;
+                var hasUser = userKey is not null
+                    && userKey.Length > 0
+                    && usersById.TryGetValue(userKey, out user);
 
                 if (dto.Id.HasValue && existingById.TryGetValue(dto.Id.Value, out var att))
                 {


### PR DESCRIPTION
## Summary
- initialize the attendee lookup `user` variable before evaluating dictionary access
- prevent C# definite assignment error when attendee user IDs are missing

## Testing
- not run (dotnet SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e64a9c702c83208d9d0bf6aa4ddca5