### PR TITLE
Handle meeting attendee removal without concurrency conflicts

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/UpdateMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/UpdateMeetingHandler.cs
@@ -36,6 +36,7 @@ public class UpdateMeetingHandler : IRequestHandler<UpdateMeetingCommand, bool>
         entity.Location = string.IsNullOrWhiteSpace(request.Location) ? "TBD" : request.Location.Trim();
 
         // Attendees
+        List<Guid>? removedAttendeeIds = null;
         if (request.AttendeesRich is not null)
         {
             var existingById = entity.Attendees.ToDictionary(a => a.Id, a => a);
@@ -116,10 +117,16 @@ public class UpdateMeetingHandler : IRequestHandler<UpdateMeetingCommand, bool>
             var toRemove = entity.Attendees
                 .Where(a => originalIds.Contains(a.Id) && !keepIds.Contains(a.Id))
                 .ToList();
-            foreach (var r in toRemove)
+
+            if (toRemove.Count > 0)
             {
-                entity.Attendees.Remove(r);
-                _db.Set<MeetingAttendee>().Remove(r);
+                removedAttendeeIds = new List<Guid>(toRemove.Count);
+                foreach (var r in toRemove)
+                {
+                    entity.Attendees.Remove(r);
+                    removedAttendeeIds.Add(r.Id);
+                    _db.Entry(r).State = EntityState.Detached;
+                }
             }
         }
 
@@ -128,7 +135,35 @@ public class UpdateMeetingHandler : IRequestHandler<UpdateMeetingCommand, bool>
         var (_, joinUrl) = await svc.UpdateEventAsync(entity, ct);
         entity.OnlineJoinUrl = joinUrl;
 
-        await _db.SaveChangesAsync(ct);
+        if (removedAttendeeIds is { Count: > 0 })
+        {
+            if (_db.Database.CurrentTransaction is null)
+            {
+                await using var tx = await _db.Database.BeginTransactionAsync(ct);
+                await PersistAttendeesAsync(ct);
+                await tx.CommitAsync(ct);
+            }
+            else
+            {
+                await PersistAttendeesAsync(ct);
+            }
+        }
+        else
+        {
+            await _db.SaveChangesAsync(ct);
+        }
         return true;
+
+        async Task PersistAttendeesAsync(CancellationToken cancellationToken)
+        {
+            if (removedAttendeeIds is { Count: > 0 })
+            {
+                await _db.Set<MeetingAttendee>()
+                    .Where(a => removedAttendeeIds.Contains(a.Id))
+                    .ExecuteDeleteAsync(cancellationToken);
+            }
+
+            await _db.SaveChangesAsync(cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- update the meeting update handler to track removed attendees, detach them, and delete them with ExecuteDeleteAsync so EF no longer raises concurrency exceptions
- wrap attendee deletions and remaining SaveChanges in a transaction when necessary to keep persistence consistent

## Testing
- not run (dotnet SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e64bf96e1883208caa32d4e787e7d1