### PR TITLE
Refine data access abstractions

### DIFF
--- a/src/BoardMgmt.Application/Calendars/Commands/MoveCalendarEventHandler.cs
+++ b/src/BoardMgmt.Application/Calendars/Commands/MoveCalendarEventHandler.cs
@@ -1,7 +1,8 @@
-﻿// Application/Calendars/Commands/MoveCalendarEventHandler.cs
-using BoardMgmt.Domain.Entities;
+// Application/Calendars/Commands/MoveCalendarEventHandler.cs
 using BoardMgmt.Application.Calendars;
+using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Domain.Calendars;
+using BoardMgmt.Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -9,10 +10,10 @@ namespace BoardMgmt.Application.Calendars.Commands
 {
     public sealed class MoveCalendarEventHandler : IRequestHandler<MoveCalendarEventCommand, bool>
     {
-        private readonly DbContext _db;
+        private readonly IAppDbContext _db;
         private readonly ICalendarServiceSelector _calSelector;
 
-        public MoveCalendarEventHandler(DbContext db, ICalendarServiceSelector calSelector)
+        public MoveCalendarEventHandler(IAppDbContext db, ICalendarServiceSelector calSelector)
         {
             _db = db;
             _calSelector = calSelector;

--- a/src/BoardMgmt.Application/Chat/Handlers/AddChatAttachmentsHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/AddChatAttachmentsHandler.cs
@@ -1,14 +1,15 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class AddChatAttachmentsHandler : IRequestHandler<AddChatAttachmentsCommand, int>
 {
-    private readonly DbContext _db;
-    public AddChatAttachmentsHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public AddChatAttachmentsHandler(IAppDbContext db) => _db = db;
 
     public async Task<int> Handle(AddChatAttachmentsCommand req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/CreateChannelHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/CreateChannelHandler.cs
@@ -1,14 +1,15 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class CreateChannelHandler : IRequestHandler<CreateChannelCommand, Guid>
 {
-    private readonly DbContext _db;
-    public CreateChannelHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public CreateChannelHandler(IAppDbContext db) => _db = db;
 
     public async Task<Guid> Handle(CreateChannelCommand req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/CreateDirectConversationHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/CreateDirectConversationHandler.cs
@@ -1,15 +1,16 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
 using BoardMgmt.Domain.Entities;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class CreateDirectConversationHandler : IRequestHandler<CreateDirectConversationCommand, Guid>
 {
-    private readonly DbContext _db;
-    public CreateDirectConversationHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public CreateDirectConversationHandler(IAppDbContext db) => _db = db;
 
     public async Task<Guid> Handle(CreateDirectConversationCommand req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/CreateOrGetDirectConversationHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/CreateOrGetDirectConversationHandler.cs
@@ -1,16 +1,16 @@
-﻿using MediatR;
-using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Domain.Chat;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
 
 namespace BoardMgmt.Application.Chat.Handlers;
 
 public sealed class CreateOrGetDirectConversationHandler
     : IRequestHandler<CreateOrGetDirectConversationCommand, Guid>
 {
-    private readonly DbContext _db;
+    private readonly IAppDbContext _db;
 
-    public CreateOrGetDirectConversationHandler(DbContext db) => _db = db;
+    public CreateOrGetDirectConversationHandler(IAppDbContext db) => _db = db;
 
     public async Task<Guid> Handle(CreateOrGetDirectConversationCommand request, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/DeleteChatMessageHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/DeleteChatMessageHandler.cs
@@ -1,14 +1,15 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class DeleteChatMessageHandler : IRequestHandler<DeleteChatMessageCommand, bool>
 {
-    private readonly DbContext _db;
-    public DeleteChatMessageHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public DeleteChatMessageHandler(IAppDbContext db) => _db = db;
 
     public async Task<bool> Handle(DeleteChatMessageCommand req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/EditChatMessageHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/EditChatMessageHandler.cs
@@ -1,14 +1,15 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class EditChatMessageHandler : IRequestHandler<EditChatMessageCommand, bool>
 {
-    private readonly DbContext _db;
-    public EditChatMessageHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public EditChatMessageHandler(IAppDbContext db) => _db = db;
 
     public async Task<bool> Handle(EditChatMessageCommand req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/GetConversationHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/GetConversationHandler.cs
@@ -1,15 +1,16 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
 using BoardMgmt.Domain.Entities;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class GetConversationHandler : IRequestHandler<GetConversationQuery, ConversationDetailDto>
 {
-    private readonly DbContext _db;
-    public GetConversationHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public GetConversationHandler(IAppDbContext db) => _db = db;
 
     public async Task<ConversationDetailDto> Handle(GetConversationQuery req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/GetHistoryHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/GetHistoryHandler.cs
@@ -1,15 +1,16 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
 using BoardMgmt.Domain.Entities;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class GetHistoryHandler : IRequestHandler<GetHistoryQuery, PagedResult<ChatMessageDto>>
 {
-    private readonly DbContext _db;
-    public GetHistoryHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public GetHistoryHandler(IAppDbContext db) => _db = db;
 
     public async Task<PagedResult<ChatMessageDto>> Handle(GetHistoryQuery req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/GetThreadConversationIdHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/GetThreadConversationIdHandler.cs
@@ -1,14 +1,15 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class GetThreadConversationIdHandler : IRequestHandler<GetThreadConversationIdQuery, Guid>
 {
-    private readonly DbContext _db;
-    public GetThreadConversationIdHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public GetThreadConversationIdHandler(IAppDbContext db) => _db = db;
 
     public async Task<Guid> Handle(GetThreadConversationIdQuery req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/JoinChannelHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/JoinChannelHandler.cs
@@ -1,14 +1,15 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class JoinChannelHandler : IRequestHandler<JoinChannelCommand, bool>
 {
-    private readonly DbContext _db;
-    public JoinChannelHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public JoinChannelHandler(IAppDbContext db) => _db = db;
 
     public async Task<bool> Handle(JoinChannelCommand req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/LeaveConversationHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/LeaveConversationHandler.cs
@@ -1,14 +1,15 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class LeaveConversationHandler : IRequestHandler<LeaveConversationCommand, bool>
 {
-    private readonly DbContext _db;
-    public LeaveConversationHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public LeaveConversationHandler(IAppDbContext db) => _db = db;
 
     public async Task<bool> Handle(LeaveConversationCommand req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/LeaveConversationHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/LeaveConversationHandler.cs
@@ -17,7 +17,7 @@ public sealed class LeaveConversationHandler : IRequestHandler<LeaveConversation
             .FirstOrDefaultAsync(m => m.ConversationId == req.ConversationId && m.UserId == req.UserId, ct);
         if (member is null) return false;
 
-        _db.Remove(member);
+        _db.Set<ConversationMember>().Remove(member);
         await _db.SaveChangesAsync(ct);
         return true;
     }

--- a/src/BoardMgmt.Application/Chat/Handlers/ListConversationsHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/ListConversationsHandler.cs
@@ -1,14 +1,15 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class ListConversationsHandler : IRequestHandler<ListConversationsQuery, IReadOnlyList<ConversationListItemDto>>
 {
-    private readonly DbContext _db;
-    public ListConversationsHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public ListConversationsHandler(IAppDbContext db) => _db = db;
 
     public async Task<IReadOnlyList<ConversationListItemDto>> Handle(ListConversationsQuery req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/MarkConversationReadHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/MarkConversationReadHandler.cs
@@ -1,14 +1,15 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class MarkConversationReadHandler : IRequestHandler<MarkConversationReadCommand, bool>
 {
-    private readonly DbContext _db;
-    public MarkConversationReadHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public MarkConversationReadHandler(IAppDbContext db) => _db = db;
 
     public async Task<bool> Handle(MarkConversationReadCommand req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/ReactionHandlers.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/ReactionHandlers.cs
@@ -42,7 +42,7 @@ public sealed class RemoveReactionHandler : IRequestHandler<RemoveReactionComman
             .FirstOrDefaultAsync(x => x.MessageId == req.MessageId && x.UserId == req.UserId && x.Emoji == req.Emoji, ct);
         if (r is null) return true;
 
-        _db.Remove(r);
+        _db.Set<ChatReaction>().Remove(r);
         await _db.SaveChangesAsync(ct);
         return true;
     }

--- a/src/BoardMgmt.Application/Chat/Handlers/ReactionHandlers.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/ReactionHandlers.cs
@@ -1,14 +1,15 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class AddReactionHandler : IRequestHandler<AddReactionCommand, bool>
 {
-    private readonly DbContext _db;
-    public AddReactionHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public AddReactionHandler(IAppDbContext db) => _db = db;
 
     public async Task<bool> Handle(AddReactionCommand req, CancellationToken ct)
     {
@@ -32,8 +33,8 @@ public sealed class AddReactionHandler : IRequestHandler<AddReactionCommand, boo
 
 public sealed class RemoveReactionHandler : IRequestHandler<RemoveReactionCommand, bool>
 {
-    private readonly DbContext _db;
-    public RemoveReactionHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public RemoveReactionHandler(IAppDbContext db) => _db = db;
 
     public async Task<bool> Handle(RemoveReactionCommand req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/SearchMessagesHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/SearchMessagesHandler.cs
@@ -1,15 +1,16 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
 using BoardMgmt.Domain.Entities;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class SearchMessagesHandler : IRequestHandler<SearchMessagesQuery, IReadOnlyList<ChatMessageDto>>
 {
-    private readonly DbContext _db;
-    public SearchMessagesHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public SearchMessagesHandler(IAppDbContext db) => _db = db;
 
     public async Task<IReadOnlyList<ChatMessageDto>> Handle(SearchMessagesQuery req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Chat/Handlers/SendChatMessageHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/SendChatMessageHandler.cs
@@ -1,14 +1,15 @@
-﻿namespace BoardMgmt.Application.Chat.Handlers;
+namespace BoardMgmt.Application.Chat.Handlers;
 
 using BoardMgmt.Application.Chat;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using BoardMgmt.Domain.Chat;
+using BoardMgmt.Application.Common.Interfaces;
 
 public sealed class SendChatMessageHandler : IRequestHandler<SendChatMessageCommand, Guid>
 {
-    private readonly DbContext _db;
-    public SendChatMessageHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public SendChatMessageHandler(IAppDbContext db) => _db = db;
 
     public async Task<Guid> Handle(SendChatMessageCommand req, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Common/Interfaces/IAppDbContext.cs
+++ b/src/BoardMgmt.Application/Common/Interfaces/IAppDbContext.cs
@@ -1,8 +1,9 @@
-﻿using BoardMgmt.Domain.Entities;
+using System.Threading.Tasks;
+using System.Threading;
+using BoardMgmt.Domain.Chat;
+using BoardMgmt.Domain.Entities;
 using BoardMgmt.Domain.Identity;
 using Microsoft.EntityFrameworkCore;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace BoardMgmt.Application.Common.Interfaces
 {
@@ -20,9 +21,22 @@ namespace BoardMgmt.Application.Common.Interfaces
         DbSet<VoteEligibleUser> VoteEligibleUsers { get; }
 
         DbSet<RolePermission> RolePermissions { get; }
+        DbSet<DocumentRoleAccess> DocumentRoleAccess { get; }
 
-        // NEW
         DbSet<Department> Departments { get; }
+        DbSet<Transcript> Transcripts { get; }
+        DbSet<TranscriptUtterance> TranscriptUtterances { get; }
+        DbSet<GeneratedReport> GeneratedReports { get; }
+
+        DbSet<Conversation> Conversations { get; }
+        DbSet<ConversationMember> ConversationMembers { get; }
+        DbSet<ChatMessage> ChatMessages { get; }
+        DbSet<ChatAttachment> ChatAttachments { get; }
+        DbSet<ChatReaction> ChatReactions { get; }
+
+        DbSet<AppUser> Users { get; }
+
+        DbSet<TEntity> Set<TEntity>() where TEntity : class;
 
         Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
     }

--- a/src/BoardMgmt.Application/Departments/Commands/CreateDepartment.cs
+++ b/src/BoardMgmt.Application/Departments/Commands/CreateDepartment.cs
@@ -4,24 +4,29 @@ using BoardMgmt.Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
+namespace BoardMgmt.Application.Departments.Commands;
+
 public sealed record CreateDepartmentCommand(string Name, string? Description)
   : IRequest<DepartmentDto>;
 
-public sealed class CreateDepartmentHandler(IAppDbContext db)
-  : IRequestHandler<CreateDepartmentCommand, DepartmentDto>
+public sealed class CreateDepartmentHandler : IRequestHandler<CreateDepartmentCommand, DepartmentDto>
 {
+    private readonly IAppDbContext _db;
+
+    public CreateDepartmentHandler(IAppDbContext db) => _db = db;
+
     public async Task<DepartmentDto> Handle(CreateDepartmentCommand request, CancellationToken ct)
     {
         var name = request.Name?.Trim();
         if (string.IsNullOrWhiteSpace(name))
             throw new InvalidOperationException("Name is required.");
 
-        var exists = await db.Departments.AnyAsync(d => d.Name == name, ct);
+        var exists = await _db.Departments.AnyAsync(d => d.Name == name, ct);
         if (exists) throw new InvalidOperationException("Department with same name already exists.");
 
         var d = new Department { Name = name, Description = request.Description };
-        db.Departments.Add(d);
-        await db.SaveChangesAsync(ct);
+        _db.Departments.Add(d);
+        await _db.SaveChangesAsync(ct);
 
         return new DepartmentDto(d.Id, d.Name, d.Description, d.IsActive);
     }

--- a/src/BoardMgmt.Application/Departments/Commands/DeleteDepartment.cs
+++ b/src/BoardMgmt.Application/Departments/Commands/DeleteDepartment.cs
@@ -1,22 +1,28 @@
-﻿using BoardMgmt.Application.Common.Interfaces;
+using System.Linq;
+using BoardMgmt.Application.Common.Interfaces;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
+namespace BoardMgmt.Application.Departments.Commands;
+
 public sealed record DeleteDepartmentCommand(Guid Id) : IRequest<bool>;
 
-public sealed class DeleteDepartmentHandler(IAppDbContext db)
-  : IRequestHandler<DeleteDepartmentCommand, bool>
+public sealed class DeleteDepartmentHandler : IRequestHandler<DeleteDepartmentCommand, bool>
 {
+    private readonly IAppDbContext _db;
+
+    public DeleteDepartmentHandler(IAppDbContext db) => _db = db;
+
     public async Task<bool> Handle(DeleteDepartmentCommand request, CancellationToken ct)
     {
-        var d = await db.Departments.Include(x => x.Users)
-                                    .FirstOrDefaultAsync(x => x.Id == request.Id, ct);
+        var d = await _db.Departments.Include(x => x.Users)
+                                     .FirstOrDefaultAsync(x => x.Id == request.Id, ct);
         if (d is null) return false;
         if (d.Users.Any())
             throw new InvalidOperationException("Cannot delete a department with assigned users.");
 
-        db.Departments.Remove(d);
-        await db.SaveChangesAsync(ct);
+        _db.Departments.Remove(d);
+        await _db.SaveChangesAsync(ct);
         return true;
     }
 }

--- a/src/BoardMgmt.Application/Departments/Commands/UpdateDepartment.cs
+++ b/src/BoardMgmt.Application/Departments/Commands/UpdateDepartment.cs
@@ -3,29 +3,34 @@ using BoardMgmt.Application.Departments.DTOs;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
+namespace BoardMgmt.Application.Departments.Commands;
+
 public sealed record UpdateDepartmentCommand(Guid Id, string Name, string? Description, bool IsActive)
   : IRequest<DepartmentDto>;
 
-public sealed class UpdateDepartmentHandler(IAppDbContext db)
-  : IRequestHandler<UpdateDepartmentCommand, DepartmentDto>
+public sealed class UpdateDepartmentHandler : IRequestHandler<UpdateDepartmentCommand, DepartmentDto>
 {
+    private readonly IAppDbContext _db;
+
+    public UpdateDepartmentHandler(IAppDbContext db) => _db = db;
+
     public async Task<DepartmentDto> Handle(UpdateDepartmentCommand request, CancellationToken ct)
     {
-        var d = await db.Departments.FirstOrDefaultAsync(x => x.Id == request.Id, ct)
+        var d = await _db.Departments.FirstOrDefaultAsync(x => x.Id == request.Id, ct)
                 ?? throw new KeyNotFoundException("Department not found.");
 
         var name = request.Name?.Trim() ?? "";
         if (string.IsNullOrWhiteSpace(name))
             throw new InvalidOperationException("Name is required.");
 
-        var clash = await db.Departments.AnyAsync(x => x.Id != d.Id && x.Name == name, ct);
+        var clash = await _db.Departments.AnyAsync(x => x.Id != d.Id && x.Name == name, ct);
         if (clash) throw new InvalidOperationException("Another department already has this name.");
 
         d.Name = name;
         d.Description = request.Description;
         d.IsActive = request.IsActive;
 
-        await db.SaveChangesAsync(ct);
+        await _db.SaveChangesAsync(ct);
         return new DepartmentDto(d.Id, d.Name, d.Description, d.IsActive);
     }
 }

--- a/src/BoardMgmt.Application/Departments/Queries/GetDepartments.cs
+++ b/src/BoardMgmt.Application/Departments/Queries/GetDepartments.cs
@@ -1,17 +1,23 @@
-﻿using BoardMgmt.Application.Common.Interfaces;
+using System.Linq;
+using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Departments.DTOs;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
+namespace BoardMgmt.Application.Departments.Queries;
+
 public sealed record GetDepartmentsQuery(string? Q = null, bool? ActiveOnly = null)
   : IRequest<IReadOnlyList<DepartmentDto>>;
 
-public sealed class GetDepartmentsHandler(IAppDbContext db)
-  : IRequestHandler<GetDepartmentsQuery, IReadOnlyList<DepartmentDto>>
+public sealed class GetDepartmentsHandler : IRequestHandler<GetDepartmentsQuery, IReadOnlyList<DepartmentDto>>
 {
+    private readonly IAppDbContext _db;
+
+    public GetDepartmentsHandler(IAppDbContext db) => _db = db;
+
     public async Task<IReadOnlyList<DepartmentDto>> Handle(GetDepartmentsQuery request, CancellationToken ct)
     {
-        var q = db.Departments.AsNoTracking();
+        var q = _db.Departments.AsNoTracking();
 
         if (!string.IsNullOrWhiteSpace(request.Q))
         {

--- a/src/BoardMgmt.Application/Folders/Commands/CreateFolder/CreateFolderCommandHandler.cs
+++ b/src/BoardMgmt.Application/Folders/Commands/CreateFolder/CreateFolderCommandHandler.cs
@@ -1,4 +1,4 @@
-﻿using BoardMgmt.Application.Common.Interfaces;
+using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Common.Utilities;
 using BoardMgmt.Application.Folders.DTOs;
 using BoardMgmt.Domain.Entities;

--- a/src/BoardMgmt.Application/Folders/Queries/GetFolders/GetFoldersQueryHandler.cs
+++ b/src/BoardMgmt.Application/Folders/Queries/GetFolders/GetFoldersQueryHandler.cs
@@ -1,4 +1,4 @@
-﻿// File: src/BoardMgmt.Application/Folders/Queries/GetFolders/GetFoldersQueryHandler.cs
+// File: src/BoardMgmt.Application/Folders/Queries/GetFolders/GetFoldersQueryHandler.cs
 using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Folders.DTOs;
 using MediatR;

--- a/src/BoardMgmt.Application/Meetings/Commands/CreateMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/CreateMeetingHandler.cs
@@ -77,9 +77,9 @@ public class CreateMeetingHandler : IRequestHandler<CreateMeetingCommand, Guid>
 
         // Create in chosen provider
         var svc = _calSelector.For(request.Provider);
-        var (eventId, joinUrl) = await svc.CreateEventAsync(entity, ct);
-        entity.ExternalEventId = eventId;
-        entity.OnlineJoinUrl = joinUrl;
+        var createResult = await svc.CreateEventAsync(entity, ct);
+        entity.ExternalEventId = createResult.eventId;
+        entity.OnlineJoinUrl = createResult.joinUrl;
 
 
         _db.Set<Meeting>().Add(entity);

--- a/src/BoardMgmt.Application/Meetings/Commands/CreateMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/CreateMeetingHandler.cs
@@ -1,8 +1,8 @@
-﻿// Application/Meetings/Commands/CreateMeetingHandler.cs
+// Application/Meetings/Commands/CreateMeetingHandler.cs
 using BoardMgmt.Application.Calendars;
 using BoardMgmt.Application.Common.Interfaces;
-using BoardMgmt.Domain.Entities;
 using BoardMgmt.Domain.Calendars;
+using BoardMgmt.Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,12 +12,12 @@ namespace BoardMgmt.Application.Meetings.Commands;
 
 public class CreateMeetingHandler : IRequestHandler<CreateMeetingCommand, Guid>
 {
-    private readonly DbContext _db;
+    private readonly IAppDbContext _db;
     private readonly IIdentityUserReader _users;
     private readonly ICalendarServiceSelector _calSelector;
 
 
-    public CreateMeetingHandler(DbContext db, IIdentityUserReader users, ICalendarServiceSelector calSelector)
+    public CreateMeetingHandler(IAppDbContext db, IIdentityUserReader users, ICalendarServiceSelector calSelector)
     {
         _db = db;
         _users = users;

--- a/src/BoardMgmt.Application/Meetings/Commands/DeleteMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/DeleteMeetingHandler.cs
@@ -30,7 +30,7 @@ namespace BoardMgmt.Application.Meetings.Commands
                 await svc.CancelEventAsync(entity.ExternalEventId, ct); // ✅ correct method
             }
 
-            _db.Remove(entity);
+            _db.Set<Meeting>().Remove(entity);
             await _db.SaveChangesAsync(ct);
             return true;
         }

--- a/src/BoardMgmt.Application/Meetings/Commands/DeleteMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/DeleteMeetingHandler.cs
@@ -1,5 +1,6 @@
-﻿// Application/Meetings/Commands/DeleteMeetingHandler.cs
+// Application/Meetings/Commands/DeleteMeetingHandler.cs
 using BoardMgmt.Application.Calendars;
+using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -8,10 +9,10 @@ namespace BoardMgmt.Application.Meetings.Commands
 {
     public sealed class DeleteMeetingHandler : IRequestHandler<DeleteMeetingCommand, bool>
     {
-        private readonly DbContext _db;
+        private readonly IAppDbContext _db;
         private readonly ICalendarServiceSelector _calSelector;
 
-        public DeleteMeetingHandler(DbContext db, ICalendarServiceSelector calSelector)
+        public DeleteMeetingHandler(IAppDbContext db, ICalendarServiceSelector calSelector)
         {
             _db = db;
             _calSelector = calSelector;

--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -391,7 +391,7 @@ namespace BoardMgmt.Application.Meetings.Commands
             var vttBytes = BuildVttFromUtterances(transcript);
             var attachment = ("transcript.vtt", "text/vtt", vttBytes);
 
-            var recipients = meeting.Attendees
+            List<string> recipients = meeting.Attendees
                 .Select(a => a.Email)
                 .Where(e => !string.IsNullOrWhiteSpace(e))
                 .Select(e => e!.Trim())

--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -276,7 +276,7 @@ namespace BoardMgmt.Application.Meetings.Commands
             foreach (var cue in SimpleVtt.Parse(vtt))
                 tr.Utterances.Add(MapUtterance(meeting, tr, cue));
 
-            _db.Add(tr);
+            await _db.Set<Transcript>().AddAsync(tr, ct);
             await _db.SaveChangesAsync(ct);
             return tr.Utterances.Count;
         }

--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -96,8 +96,11 @@ namespace BoardMgmt.Application.Meetings.Commands
                 .Content
                 .GetAsync(cancellationToken: ct);
 
+            if (stream is null)
+                throw new InvalidOperationException("Teams returned an empty transcript stream.");
+
             using var reader = new System.IO.StreamReader(stream);
-            var vtt = await reader.ReadToEndAsync();
+            var vtt = await reader.ReadToEndAsync(ct);
             if (string.IsNullOrWhiteSpace(vtt))
                 throw new InvalidOperationException("Teams returned an empty transcript content.");
 
@@ -391,6 +394,7 @@ namespace BoardMgmt.Application.Meetings.Commands
             var recipients = meeting.Attendees
                 .Select(a => a.Email)
                 .Where(e => !string.IsNullOrWhiteSpace(e))
+                .Select(e => e!.Trim())
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
 

--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -1,13 +1,14 @@
-﻿using System;
 using System.Linq;
-using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
+using System.Net.Http;
 using System.Text.Json;
-using System.Threading;
+using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
+using System;
 using BoardMgmt.Application.Calendars;
 using BoardMgmt.Application.Common.Email;
+using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Common.Options;
 using BoardMgmt.Application.Common.Parsing; // SimpleVtt
 using BoardMgmt.Domain.Entities;
@@ -20,7 +21,7 @@ namespace BoardMgmt.Application.Meetings.Commands
 {
     public sealed class IngestTranscriptHandler : IRequestHandler<IngestTranscriptCommand, int>
     {
-        private readonly DbContext _db;
+        private readonly IAppDbContext _db;
         private readonly GraphServiceClient _graph;
         private readonly IHttpClientFactory _httpFactory;
         private readonly IZoomTokenProvider _zoomTokenProvider;
@@ -28,7 +29,7 @@ namespace BoardMgmt.Application.Meetings.Commands
         private readonly AppOptions _app;
 
         public IngestTranscriptHandler(
-            DbContext db,
+            IAppDbContext db,
             GraphServiceClient graph,
             IHttpClientFactory httpFactory,
             IZoomTokenProvider zoomTokenProvider,

--- a/src/BoardMgmt.Application/Meetings/Commands/UpdateMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/UpdateMeetingHandler.cs
@@ -131,8 +131,8 @@ public class UpdateMeetingHandler : IRequestHandler<UpdateMeetingCommand, bool>
 
         // Calendar provider update (optional)
         var svc = _calSelector.For(entity.ExternalCalendar ?? CalendarProviders.Microsoft365);
-        var (_, joinUrl) = await svc.UpdateEventAsync(entity, ct);
-        entity.OnlineJoinUrl = joinUrl;
+        var updateResult = await svc.UpdateEventAsync(entity, ct);
+        entity.OnlineJoinUrl = updateResult.joinUrl;
 
         await SaveChangesHandlingRemovedAttendeesAsync(ct);
         return true;

--- a/src/BoardMgmt.Application/Meetings/Commands/UpdateMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/UpdateMeetingHandler.cs
@@ -10,11 +10,11 @@ namespace BoardMgmt.Application.Meetings.Commands;
 
 public class UpdateMeetingHandler : IRequestHandler<UpdateMeetingCommand, bool>
 {
-    private readonly DbContext _db;
+    private readonly IAppDbContext _db;
     private readonly IIdentityUserReader _users;
     private readonly ICalendarServiceSelector _calSelector;
 
-    public UpdateMeetingHandler(DbContext db, IIdentityUserReader users, ICalendarServiceSelector calSelector)
+    public UpdateMeetingHandler(IAppDbContext db, IIdentityUserReader users, ICalendarServiceSelector calSelector)
     {
         _db = db;
         _users = users;

--- a/src/BoardMgmt.Application/Meetings/Queries/GetCalendarRangeFromDbHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Queries/GetCalendarRangeFromDbHandler.cs
@@ -1,4 +1,4 @@
-﻿// Application/Calendars/Queries/GetCalendarRangeFromDbHandler.cs
+// Application/Calendars/Queries/GetCalendarRangeFromDbHandler.cs
 using BoardMgmt.Application.Calendars;
 using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Domain.Entities;
@@ -10,10 +10,10 @@ namespace BoardMgmt.Application.Calendars.Queries;
 public sealed class GetCalendarRangeFromDbHandler
   : IRequestHandler<GetCalendarRangeFromDbQuery, IReadOnlyList<CalendarEventDto>>
 {
-    private readonly DbContext _db;
+    private readonly IAppDbContext _db;
     private readonly ICurrentUser _current;
 
-    public GetCalendarRangeFromDbHandler(DbContext db, ICurrentUser current)
+    public GetCalendarRangeFromDbHandler(IAppDbContext db, ICurrentUser current)
     {
         _db = db;
         _current = current;

--- a/src/BoardMgmt.Application/Meetings/Queries/GetMeetingByIdQueryHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Queries/GetMeetingByIdQueryHandler.cs
@@ -1,4 +1,5 @@
-﻿using BoardMgmt.Application.Meetings.DTOs;
+using BoardMgmt.Application.Common.Interfaces;
+using BoardMgmt.Application.Meetings.DTOs;
 using BoardMgmt.Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -7,8 +8,8 @@ namespace BoardMgmt.Application.Meetings.Queries;
 
 public sealed class GetMeetingByIdQueryHandler : IRequestHandler<GetMeetingByIdQuery, MeetingDto?>
 {
-    private readonly DbContext _db;
-    public GetMeetingByIdQueryHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public GetMeetingByIdQueryHandler(IAppDbContext db) => _db = db;
 
     public async Task<MeetingDto?> Handle(GetMeetingByIdQuery request, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Meetings/Queries/GetMeetingsQueryHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Queries/GetMeetingsQueryHandler.cs
@@ -1,22 +1,22 @@
-﻿// Application/Meetings/Queries/GetMeetingsQueryHandler.cs
+// Application/Meetings/Queries/GetMeetingsQueryHandler.cs
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Threading;
 using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Meetings.DTOs;
 using BoardMgmt.Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace BoardMgmt.Application.Meetings.Queries;
 
 public class GetMeetingsQueryHandler : IRequestHandler<GetMeetingsQuery, IReadOnlyList<MeetingDto>>
 {
-    private readonly DbContext _db;
+    private readonly IAppDbContext _db;
     private readonly ICurrentUser _current;
 
-    public GetMeetingsQueryHandler(DbContext db, ICurrentUser current)
+    public GetMeetingsQueryHandler(IAppDbContext db, ICurrentUser current)
     {
         _db = db;
         _current = current;

--- a/src/BoardMgmt.Application/Meetings/Queries/GetMeetingsSelectListHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Queries/GetMeetingsSelectListHandler.cs
@@ -1,4 +1,4 @@
-﻿using BoardMgmt.Application.Common.Interfaces;
+using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Meetings.DTOs;
 using MediatR;
 using Microsoft.EntityFrameworkCore;

--- a/src/BoardMgmt.Application/Meetings/Queries/GetTranscriptByMeetingIdHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Queries/GetTranscriptByMeetingIdHandler.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Meetings.DTOs;
 using BoardMgmt.Domain.Entities;

--- a/src/BoardMgmt.Application/Meetings/Queries/GetTranscriptByMeetingIdHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Queries/GetTranscriptByMeetingIdHandler.cs
@@ -1,4 +1,5 @@
-﻿using BoardMgmt.Application.Meetings.DTOs;
+using BoardMgmt.Application.Common.Interfaces;
+using BoardMgmt.Application.Meetings.DTOs;
 using BoardMgmt.Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -7,8 +8,8 @@ namespace BoardMgmt.Application.Meetings.Queries;
 
 public sealed class GetTranscriptByMeetingIdHandler : IRequestHandler<GetTranscriptByMeetingIdQuery, TranscriptDto?>
 {
-    private readonly DbContext _db;
-    public GetTranscriptByMeetingIdHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public GetTranscriptByMeetingIdHandler(IAppDbContext db) => _db = db;
 
     public async Task<TranscriptDto?> Handle(GetTranscriptByMeetingIdQuery request, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Reports/Commands/GenerateReportHandler.cs
+++ b/src/BoardMgmt.Application/Reports/Commands/GenerateReportHandler.cs
@@ -68,7 +68,7 @@ public sealed class GenerateReportHandler : IRequestHandler<GenerateReportComman
             EndDate = end
         };
 
-        _db.Add(entity);
+        await _db.Set<GeneratedReport>().AddAsync(entity, ct);
         await _db.SaveChangesAsync(ct);
 
         return id;

--- a/src/BoardMgmt.Application/Reports/Commands/GenerateReportHandler.cs
+++ b/src/BoardMgmt.Application/Reports/Commands/GenerateReportHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+using System.Text;
+using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Http;
@@ -9,11 +10,11 @@ namespace BoardMgmt.Application.Reports.Commands;
 
 public sealed class GenerateReportHandler : IRequestHandler<GenerateReportCommand, Guid>
 {
-    private readonly DbContext _db;
+    private readonly IAppDbContext _db;
     private readonly IHostEnvironment _env;
     private readonly IHttpContextAccessor _http;
 
-    public GenerateReportHandler(DbContext db, IHostEnvironment env, IHttpContextAccessor http)
+    public GenerateReportHandler(IAppDbContext db, IHostEnvironment env, IHttpContextAccessor http)
     {
         _db = db; _env = env; _http = http;
     }

--- a/src/BoardMgmt.Application/Reports/Queries/GetRecentReportsQuery.cs
+++ b/src/BoardMgmt.Application/Reports/Queries/GetRecentReportsQuery.cs
@@ -1,4 +1,5 @@
-﻿using BoardMgmt.Application.Reports.DTOs;
+using BoardMgmt.Application.Common.Interfaces;
+using BoardMgmt.Application.Reports.DTOs;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -8,8 +9,8 @@ public record GetRecentReportsQuery(int Take = 10) : IRequest<List<RecentReportD
 
 public sealed class GetRecentReportsHandler : IRequestHandler<GetRecentReportsQuery, List<RecentReportDto>>
 {
-    private readonly DbContext _db;
-    public GetRecentReportsHandler(DbContext db) => _db = db;
+    private readonly IAppDbContext _db;
+    public GetRecentReportsHandler(IAppDbContext db) => _db = db;
 
     public async Task<List<RecentReportDto>> Handle(GetRecentReportsQuery request, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Reports/Queries/GetReportsDashboardQuery.cs
+++ b/src/BoardMgmt.Application/Reports/Queries/GetReportsDashboardQuery.cs
@@ -1,4 +1,5 @@
-﻿using BoardMgmt.Application.Reports.DTOs;
+using BoardMgmt.Application.Common.Interfaces;
+using BoardMgmt.Application.Reports.DTOs;
 using BoardMgmt.Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -9,9 +10,9 @@ public record GetReportsDashboardQuery(int Months = 6) : IRequest<ReportsDashboa
 
 public sealed class GetReportsDashboardHandler : IRequestHandler<GetReportsDashboardQuery, ReportsDashboardDto>
 {
-    private readonly DbContext _db;
+    private readonly IAppDbContext _db;
 
-    public GetReportsDashboardHandler(DbContext db) => _db = db;
+    public GetReportsDashboardHandler(IAppDbContext db) => _db = db;
 
     public async Task<ReportsDashboardDto> Handle(GetReportsDashboardQuery request, CancellationToken ct)
     {

--- a/src/BoardMgmt.Application/Votes/Commands/CreateVoteCommand.cs
+++ b/src/BoardMgmt.Application/Votes/Commands/CreateVoteCommand.cs
@@ -1,4 +1,4 @@
-﻿using BoardMgmt.Application.Common.Interfaces;
+using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;

--- a/src/BoardMgmt.Application/Votes/Commands/SubmitBallotCommand.cs
+++ b/src/BoardMgmt.Application/Votes/Commands/SubmitBallotCommand.cs
@@ -1,4 +1,4 @@
-﻿// BoardMgmt.Application/Votes/Commands/SubmitBallotCommand.cs
+// BoardMgmt.Application/Votes/Commands/SubmitBallotCommand.cs
 using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Votes.DTOs;
 using BoardMgmt.Application.Votes.Queries;

--- a/src/BoardMgmt.Application/Votes/Queries/GetActiveVotesQuery.cs
+++ b/src/BoardMgmt.Application/Votes/Queries/GetActiveVotesQuery.cs
@@ -1,4 +1,4 @@
-﻿// BoardMgmt.Application/Votes/Queries/GetActiveVotesQuery.cs
+// BoardMgmt.Application/Votes/Queries/GetActiveVotesQuery.cs
 using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Votes.DTOs;
 using BoardMgmt.Domain.Entities;

--- a/src/BoardMgmt.Application/Votes/Queries/GetRecentVotesQuery.cs
+++ b/src/BoardMgmt.Application/Votes/Queries/GetRecentVotesQuery.cs
@@ -1,4 +1,4 @@
-﻿using BoardMgmt.Application.Common.Interfaces;
+using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Votes.DTOs;
 using MediatR;
 using Microsoft.EntityFrameworkCore;

--- a/src/BoardMgmt.Domain/BoardMgmt.Domain.csproj
+++ b/src/BoardMgmt.Domain/BoardMgmt.Domain.csproj
@@ -6,12 +6,9 @@
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<!-- Add ASP.NET Core framework reference for Identity -->
-		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-	</ItemGroup>
+        <ItemGroup>
+                <!-- Add ASP.NET Core framework reference for Identity -->
+                <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        </ItemGroup>
 
 </Project>

--- a/src/BoardMgmt.Infrastructure/DependencyInjection.cs
+++ b/src/BoardMgmt.Infrastructure/DependencyInjection.cs
@@ -101,9 +101,6 @@ namespace BoardMgmt.Infrastructure
             services.AddScoped<IJwtTokenService, JwtTokenService>();
             services.AddScoped<IIdentityUserReader, IdentityUserReader>();
 
-            // Some handlers may still take DbContext directly:
-            services.AddScoped<DbContext>(sp => sp.GetRequiredService<AppDbContext>());
-
             // Current user accessor
             services.AddHttpContextAccessor();
             services.AddScoped<ICurrentUser, CurrentUser>();

--- a/src/BoardMgmt.WebApi/Controllers/ChatController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/ChatController.cs
@@ -1,13 +1,13 @@
-﻿// Controllers/ChatController.cs
+// Controllers/ChatController.cs
+using BoardMgmt.Application.Chat;
+using BoardMgmt.Application.Common.Interfaces;
+using BoardMgmt.Domain.Chat;
+using BoardMgmt.WebApi.Hubs;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using BoardMgmt.Application.Chat;
-using BoardMgmt.Domain.Chat;
-using BoardMgmt.WebApi.Hubs;
 using Microsoft.AspNetCore.SignalR;
-using BoardMgmt.Application.Common.Interfaces;
+using Microsoft.EntityFrameworkCore;
 
 namespace BoardMgmt.WebApi.Controllers;
 
@@ -19,9 +19,9 @@ public class ChatController : ControllerBase
     private readonly ISender _mediator;
     private readonly IHubContext<ChatHub> _hub;
     private readonly ICurrentUser _current;
-    private readonly DbContext _db;
+    private readonly IAppDbContext _db;
 
-    public ChatController(ISender mediator, IHubContext<ChatHub> hub, ICurrentUser current, DbContext db)
+    public ChatController(ISender mediator, IHubContext<ChatHub> hub, ICurrentUser current, IAppDbContext db)
     {
         _mediator = mediator;
         _hub = hub;

--- a/src/BoardMgmt.WebApi/Controllers/ChatController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/ChatController.cs
@@ -220,7 +220,7 @@ public class ChatController : ControllerBase
             toSave.Add((f.FileName, f.ContentType ?? "application/octet-stream", f.Length, path));
         }
 
-        var _ = await _mediator.Send(new AddChatAttachmentsCommand(id, toSave));
+        _ = await _mediator.Send(new AddChatAttachmentsCommand(id, toSave));
 
         var atts = await _db.Set<ChatAttachment>()
             .Where(a => a.MessageId == id)

--- a/src/BoardMgmt.WebApi/Controllers/MeController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/MeController.cs
@@ -1,10 +1,10 @@
-﻿using BoardMgmt.Domain.Entities;
-using BoardMgmt.Infrastructure.Persistence;
+using BoardMgmt.Application.Common.Interfaces;
+using BoardMgmt.Domain.Entities;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 
 namespace BoardMgmt.WebApi.Controllers;
 
@@ -13,11 +13,11 @@ namespace BoardMgmt.WebApi.Controllers;
 [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
 public class MeController : ControllerBase
 {
-    private readonly AppDbContext _db;
+    private readonly IAppDbContext _db;
     private readonly UserManager<AppUser> _users;
     private readonly RoleManager<IdentityRole> _roles;
 
-    public MeController(AppDbContext db, UserManager<AppUser> users, RoleManager<IdentityRole> roles)
+    public MeController(IAppDbContext db, UserManager<AppUser> users, RoleManager<IdentityRole> roles)
     { _db = db; _users = users; _roles = roles; }
 
     [HttpGet("permissions")]

--- a/src/BoardMgmt.WebApi/Controllers/ZoomWebhookController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/ZoomWebhookController.cs
@@ -1,7 +1,8 @@
 // File: Controllers/ZoomWebhookController.cs
+using System.IO;
 using System.Security.Cryptography;
-using System.Text.Json;
 using System.Text;
+using System.Text.Json;
 using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Meetings.Commands;
 using BoardMgmt.Domain.Entities;
@@ -47,7 +48,8 @@ namespace BoardMgmt.WebApi.Controllers
         {
             try
             {
-                using var reader = new StreamReader(Request.Body, Encoding.UTF8, false, 1024, leaveOpen: true);
+                var requestBody = Request.Body ?? Stream.Null;
+                using var reader = new StreamReader(requestBody, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
                 var body = await reader.ReadToEndAsync(ct);
 
                 _logger.LogInformation(

--- a/src/BoardMgmt.WebApi/Controllers/ZoomWebhookController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/ZoomWebhookController.cs
@@ -1,10 +1,10 @@
-﻿// File: Controllers/ZoomWebhookController.cs
+// File: Controllers/ZoomWebhookController.cs
 using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
+using System.Text;
+using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Meetings.Commands;
 using BoardMgmt.Domain.Entities;
-using BoardMgmt.Infrastructure.Persistence; // your DbContext namespace
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -19,14 +19,14 @@ namespace BoardMgmt.WebApi.Controllers
     public sealed class ZoomWebhookController : ControllerBase
     {
         private readonly IMediator _mediator;
-        private readonly AppDbContext _db;                 // <-- your concrete DbContext type
+        private readonly IAppDbContext _db;
         private readonly string _secretToken;
         private readonly ILogger<ZoomWebhookController> _logger;
         private readonly bool _disableSigValidation;
 
         public ZoomWebhookController(
             IMediator mediator,
-            AppDbContext db,
+            IAppDbContext db,
             IConfiguration config,
             ILogger<ZoomWebhookController> logger)
         {


### PR DESCRIPTION
## Summary
- expose all board management aggregates through `IAppDbContext` and add a generic Set accessor to keep EF usage behind an abstraction
- update application handlers and WebApi controllers to depend on the application context abstraction instead of the concrete `DbContext`
- simplify infrastructure registration to publish only the abstraction and drop unnecessary EF package references from the Domain project

## Testing
- dotnet build *(fails: `dotnet` CLI not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e743b75cdc83209d180bd0b8e0b405