### PR TITLE
Fix application handlers to use the DbContext abstraction

### DIFF
--- a/src/BoardMgmt.Application/Chat/Handlers/LeaveConversationHandler.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/LeaveConversationHandler.cs
@@ -17,7 +17,7 @@ public sealed class LeaveConversationHandler : IRequestHandler<LeaveConversation
             .FirstOrDefaultAsync(m => m.ConversationId == req.ConversationId && m.UserId == req.UserId, ct);
         if (member is null) return false;
 
-        _db.Remove(member);
+        _db.Set<ConversationMember>().Remove(member);
         await _db.SaveChangesAsync(ct);
         return true;
     }

--- a/src/BoardMgmt.Application/Chat/Handlers/ReactionHandlers.cs
+++ b/src/BoardMgmt.Application/Chat/Handlers/ReactionHandlers.cs
@@ -42,7 +42,7 @@ public sealed class RemoveReactionHandler : IRequestHandler<RemoveReactionComman
             .FirstOrDefaultAsync(x => x.MessageId == req.MessageId && x.UserId == req.UserId && x.Emoji == req.Emoji, ct);
         if (r is null) return true;
 
-        _db.Remove(r);
+        _db.Set<ChatReaction>().Remove(r);
         await _db.SaveChangesAsync(ct);
         return true;
     }

--- a/src/BoardMgmt.Application/Meetings/Commands/DeleteMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/DeleteMeetingHandler.cs
@@ -30,7 +30,7 @@ namespace BoardMgmt.Application.Meetings.Commands
                 await svc.CancelEventAsync(entity.ExternalEventId, ct); // ✅ correct method
             }
 
-            _db.Remove(entity);
+            _db.Set<Meeting>().Remove(entity);
             await _db.SaveChangesAsync(ct);
             return true;
         }

--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -276,7 +276,7 @@ namespace BoardMgmt.Application.Meetings.Commands
             foreach (var cue in SimpleVtt.Parse(vtt))
                 tr.Utterances.Add(MapUtterance(meeting, tr, cue));
 
-            _db.Add(tr);
+            await _db.Set<Transcript>().AddAsync(tr, ct);
             await _db.SaveChangesAsync(ct);
             return tr.Utterances.Count;
         }

--- a/src/BoardMgmt.Application/Reports/Commands/GenerateReportHandler.cs
+++ b/src/BoardMgmt.Application/Reports/Commands/GenerateReportHandler.cs
@@ -68,7 +68,7 @@ public sealed class GenerateReportHandler : IRequestHandler<GenerateReportComman
             EndDate = end
         };
 
-        _db.Add(entity);
+        await _db.Set<GeneratedReport>().AddAsync(entity, ct);
         await _db.SaveChangesAsync(ct);
 
         return id;


### PR DESCRIPTION
## Summary
- adjust application handlers to interact with EF entities through `DbSet<T>` when using `IAppDbContext`
- ensure new report and transcript entities are added via the generic set helper to stay behind the abstraction

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e7499f05e083208395681155d24e5a