### PR TITLE
Fix EF context usage and transcript email handling

### DIFF
--- a/src/BoardMgmt.Application/Departments/Commands/CreateDepartment.cs
+++ b/src/BoardMgmt.Application/Departments/Commands/CreateDepartment.cs
@@ -4,24 +4,29 @@ using BoardMgmt.Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
+namespace BoardMgmt.Application.Departments.Commands;
+
 public sealed record CreateDepartmentCommand(string Name, string? Description)
   : IRequest<DepartmentDto>;
 
-public sealed class CreateDepartmentHandler(IAppDbContext db)
-  : IRequestHandler<CreateDepartmentCommand, DepartmentDto>
+public sealed class CreateDepartmentHandler : IRequestHandler<CreateDepartmentCommand, DepartmentDto>
 {
+    private readonly IAppDbContext _db;
+
+    public CreateDepartmentHandler(IAppDbContext db) => _db = db;
+
     public async Task<DepartmentDto> Handle(CreateDepartmentCommand request, CancellationToken ct)
     {
         var name = request.Name?.Trim();
         if (string.IsNullOrWhiteSpace(name))
             throw new InvalidOperationException("Name is required.");
 
-        var exists = await db.Departments.AnyAsync(d => d.Name == name, ct);
+        var exists = await _db.Departments.AnyAsync(d => d.Name == name, ct);
         if (exists) throw new InvalidOperationException("Department with same name already exists.");
 
         var d = new Department { Name = name, Description = request.Description };
-        db.Departments.Add(d);
-        await db.SaveChangesAsync(ct);
+        _db.Departments.Add(d);
+        await _db.SaveChangesAsync(ct);
 
         return new DepartmentDto(d.Id, d.Name, d.Description, d.IsActive);
     }

--- a/src/BoardMgmt.Application/Departments/Commands/UpdateDepartment.cs
+++ b/src/BoardMgmt.Application/Departments/Commands/UpdateDepartment.cs
@@ -3,29 +3,34 @@ using BoardMgmt.Application.Departments.DTOs;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
+namespace BoardMgmt.Application.Departments.Commands;
+
 public sealed record UpdateDepartmentCommand(Guid Id, string Name, string? Description, bool IsActive)
   : IRequest<DepartmentDto>;
 
-public sealed class UpdateDepartmentHandler(IAppDbContext db)
-  : IRequestHandler<UpdateDepartmentCommand, DepartmentDto>
+public sealed class UpdateDepartmentHandler : IRequestHandler<UpdateDepartmentCommand, DepartmentDto>
 {
+    private readonly IAppDbContext _db;
+
+    public UpdateDepartmentHandler(IAppDbContext db) => _db = db;
+
     public async Task<DepartmentDto> Handle(UpdateDepartmentCommand request, CancellationToken ct)
     {
-        var d = await db.Departments.FirstOrDefaultAsync(x => x.Id == request.Id, ct)
+        var d = await _db.Departments.FirstOrDefaultAsync(x => x.Id == request.Id, ct)
                 ?? throw new KeyNotFoundException("Department not found.");
 
         var name = request.Name?.Trim() ?? "";
         if (string.IsNullOrWhiteSpace(name))
             throw new InvalidOperationException("Name is required.");
 
-        var clash = await db.Departments.AnyAsync(x => x.Id != d.Id && x.Name == name, ct);
+        var clash = await _db.Departments.AnyAsync(x => x.Id != d.Id && x.Name == name, ct);
         if (clash) throw new InvalidOperationException("Another department already has this name.");
 
         d.Name = name;
         d.Description = request.Description;
         d.IsActive = request.IsActive;
 
-        await db.SaveChangesAsync(ct);
+        await _db.SaveChangesAsync(ct);
         return new DepartmentDto(d.Id, d.Name, d.Description, d.IsActive);
     }
 }

--- a/src/BoardMgmt.Application/Meetings/Commands/CreateMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/CreateMeetingHandler.cs
@@ -77,9 +77,9 @@ public class CreateMeetingHandler : IRequestHandler<CreateMeetingCommand, Guid>
 
         // Create in chosen provider
         var svc = _calSelector.For(request.Provider);
-        var (eventId, joinUrl) = await svc.CreateEventAsync(entity, ct);
-        entity.ExternalEventId = eventId;
-        entity.OnlineJoinUrl = joinUrl;
+        var createResult = await svc.CreateEventAsync(entity, ct);
+        entity.ExternalEventId = createResult.eventId;
+        entity.OnlineJoinUrl = createResult.joinUrl;
 
 
         _db.Set<Meeting>().Add(entity);

--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -96,8 +96,11 @@ namespace BoardMgmt.Application.Meetings.Commands
                 .Content
                 .GetAsync(cancellationToken: ct);
 
+            if (stream is null)
+                throw new InvalidOperationException("Teams returned an empty transcript stream.");
+
             using var reader = new System.IO.StreamReader(stream);
-            var vtt = await reader.ReadToEndAsync();
+            var vtt = await reader.ReadToEndAsync(ct);
             if (string.IsNullOrWhiteSpace(vtt))
                 throw new InvalidOperationException("Teams returned an empty transcript content.");
 
@@ -391,6 +394,7 @@ namespace BoardMgmt.Application.Meetings.Commands
             var recipients = meeting.Attendees
                 .Select(a => a.Email)
                 .Where(e => !string.IsNullOrWhiteSpace(e))
+                .Select(e => e!.Trim())
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
 

--- a/src/BoardMgmt.Application/Meetings/Commands/UpdateMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/UpdateMeetingHandler.cs
@@ -131,8 +131,8 @@ public class UpdateMeetingHandler : IRequestHandler<UpdateMeetingCommand, bool>
 
         // Calendar provider update (optional)
         var svc = _calSelector.For(entity.ExternalCalendar ?? CalendarProviders.Microsoft365);
-        var (_, joinUrl) = await svc.UpdateEventAsync(entity, ct);
-        entity.OnlineJoinUrl = joinUrl;
+        var updateResult = await svc.UpdateEventAsync(entity, ct);
+        entity.OnlineJoinUrl = updateResult.joinUrl;
 
         await SaveChangesHandlingRemovedAttendeesAsync(ct);
         return true;

--- a/src/BoardMgmt.Application/Meetings/Queries/GetTranscriptByMeetingIdHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Queries/GetTranscriptByMeetingIdHandler.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Meetings.DTOs;
 using BoardMgmt.Domain.Entities;


### PR DESCRIPTION
## Summary
- add namespaces and explicit dependencies for the department command handlers
- guard transcript ingestion against null streams and propagate cancellation tokens when reading
- normalize calendar service results and LINQ usage in meeting handlers

## Testing
- Not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e74b189f448320a0f939bc9d6b097c