### PR TITLE
Fix EF handler compilation issues and null-safety warnings

### DIFF
--- a/src/BoardMgmt.Application/Departments/Commands/DeleteDepartment.cs
+++ b/src/BoardMgmt.Application/Departments/Commands/DeleteDepartment.cs
@@ -1,22 +1,28 @@
-﻿using BoardMgmt.Application.Common.Interfaces;
+using System.Linq;
+using BoardMgmt.Application.Common.Interfaces;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
+namespace BoardMgmt.Application.Departments.Commands;
+
 public sealed record DeleteDepartmentCommand(Guid Id) : IRequest<bool>;
 
-public sealed class DeleteDepartmentHandler(IAppDbContext db)
-  : IRequestHandler<DeleteDepartmentCommand, bool>
+public sealed class DeleteDepartmentHandler : IRequestHandler<DeleteDepartmentCommand, bool>
 {
+    private readonly IAppDbContext _db;
+
+    public DeleteDepartmentHandler(IAppDbContext db) => _db = db;
+
     public async Task<bool> Handle(DeleteDepartmentCommand request, CancellationToken ct)
     {
-        var d = await db.Departments.Include(x => x.Users)
-                                    .FirstOrDefaultAsync(x => x.Id == request.Id, ct);
+        var d = await _db.Departments.Include(x => x.Users)
+                                     .FirstOrDefaultAsync(x => x.Id == request.Id, ct);
         if (d is null) return false;
         if (d.Users.Any())
             throw new InvalidOperationException("Cannot delete a department with assigned users.");
 
-        db.Departments.Remove(d);
-        await db.SaveChangesAsync(ct);
+        _db.Departments.Remove(d);
+        await _db.SaveChangesAsync(ct);
         return true;
     }
 }

--- a/src/BoardMgmt.Application/Departments/Queries/GetDepartments.cs
+++ b/src/BoardMgmt.Application/Departments/Queries/GetDepartments.cs
@@ -1,17 +1,23 @@
-﻿using BoardMgmt.Application.Common.Interfaces;
+using System.Linq;
+using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Departments.DTOs;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
+namespace BoardMgmt.Application.Departments.Queries;
+
 public sealed record GetDepartmentsQuery(string? Q = null, bool? ActiveOnly = null)
   : IRequest<IReadOnlyList<DepartmentDto>>;
 
-public sealed class GetDepartmentsHandler(IAppDbContext db)
-  : IRequestHandler<GetDepartmentsQuery, IReadOnlyList<DepartmentDto>>
+public sealed class GetDepartmentsHandler : IRequestHandler<GetDepartmentsQuery, IReadOnlyList<DepartmentDto>>
 {
+    private readonly IAppDbContext _db;
+
+    public GetDepartmentsHandler(IAppDbContext db) => _db = db;
+
     public async Task<IReadOnlyList<DepartmentDto>> Handle(GetDepartmentsQuery request, CancellationToken ct)
     {
-        var q = db.Departments.AsNoTracking();
+        var q = _db.Departments.AsNoTracking();
 
         if (!string.IsNullOrWhiteSpace(request.Q))
         {

--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -391,7 +391,7 @@ namespace BoardMgmt.Application.Meetings.Commands
             var vttBytes = BuildVttFromUtterances(transcript);
             var attachment = ("transcript.vtt", "text/vtt", vttBytes);
 
-            var recipients = meeting.Attendees
+            List<string> recipients = meeting.Attendees
                 .Select(a => a.Email)
                 .Where(e => !string.IsNullOrWhiteSpace(e))
                 .Select(e => e!.Trim())

--- a/src/BoardMgmt.WebApi/Controllers/ChatController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/ChatController.cs
@@ -220,7 +220,7 @@ public class ChatController : ControllerBase
             toSave.Add((f.FileName, f.ContentType ?? "application/octet-stream", f.Length, path));
         }
 
-        var _ = await _mediator.Send(new AddChatAttachmentsCommand(id, toSave));
+        _ = await _mediator.Send(new AddChatAttachmentsCommand(id, toSave));
 
         var atts = await _db.Set<ChatAttachment>()
             .Where(a => a.MessageId == id)

--- a/src/BoardMgmt.WebApi/Controllers/ZoomWebhookController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/ZoomWebhookController.cs
@@ -1,7 +1,8 @@
 // File: Controllers/ZoomWebhookController.cs
+using System.IO;
 using System.Security.Cryptography;
-using System.Text.Json;
 using System.Text;
+using System.Text.Json;
 using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Meetings.Commands;
 using BoardMgmt.Domain.Entities;
@@ -47,7 +48,8 @@ namespace BoardMgmt.WebApi.Controllers
         {
             try
             {
-                using var reader = new StreamReader(Request.Body, Encoding.UTF8, false, 1024, leaveOpen: true);
+                var requestBody = Request.Body ?? Stream.Null;
+                using var reader = new StreamReader(requestBody, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
                 var body = await reader.ReadToEndAsync(ct);
 
                 _logger.LogInformation(


### PR DESCRIPTION
## Summary
- add namespaces and explicit DbContext fields to department handlers
- ensure transcript email recipients are non-null and stop using `var _` discard
- guard Zoom webhook body reads against null streams before parsing

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e74d19a0348320bb1ed2dbbbf2c7f4