### PR TITLE
Fix repository DbContext injection

### DIFF
--- a/src/BoardMgmt.Infrastructure/Persistence/Repositories/DocumentReadRepository.cs
+++ b/src/BoardMgmt.Infrastructure/Persistence/Repositories/DocumentReadRepository.cs
@@ -8,13 +8,14 @@ using BoardMgmt.Application.Common.Interfaces.Repositories;
 using BoardMgmt.Application.Dashboard.DTOs;
 using BoardMgmt.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
+using BoardMgmt.Infrastructure.Persistence;
 
 namespace BoardMgmt.Infrastructure.Persistence.Repositories
 {
     public class DocumentReadRepository : IDocumentReadRepository
     {
-        private readonly DbContext _db;
-        public DocumentReadRepository(DbContext db) => _db = db;
+        private readonly AppDbContext _db;
+        public DocumentReadRepository(AppDbContext db) => _db = db;
 
         // You don't have IsActive on Document, so we just count all documents
         public Task<int> CountActiveAsync(CancellationToken ct) =>

--- a/src/BoardMgmt.Infrastructure/Persistence/Repositories/MeetingReadRepository.cs
+++ b/src/BoardMgmt.Infrastructure/Persistence/Repositories/MeetingReadRepository.cs
@@ -2,13 +2,14 @@
 using BoardMgmt.Application.Dashboard.DTOs;
 using BoardMgmt.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
+using BoardMgmt.Infrastructure.Persistence;
 
 namespace BoardMgmt.Infrastructure.Persistence.Repositories;
 
 public class MeetingReadRepository : IMeetingReadRepository
 {
-    private readonly DbContext _db;
-    public MeetingReadRepository(DbContext db) => _db = db;
+    private readonly AppDbContext _db;
+    public MeetingReadRepository(AppDbContext db) => _db = db;
 
     public Task<int> CountUpcomingAsync(DateTime utcNow, CancellationToken ct)
     {

--- a/src/BoardMgmt.Infrastructure/Persistence/Repositories/UserReadRepository.cs
+++ b/src/BoardMgmt.Infrastructure/Persistence/Repositories/UserReadRepository.cs
@@ -8,13 +8,14 @@ using BoardMgmt.Application.Common.Interfaces.Repositories;
 using BoardMgmt.Application.Dashboard.DTOs;
 using BoardMgmt.Domain.Entities;               // ✅ your AppUser
 using Microsoft.EntityFrameworkCore;
+using BoardMgmt.Infrastructure.Persistence;
 
 namespace BoardMgmt.Infrastructure.Persistence.Repositories;
 
 public class UserReadRepository : IUserReadRepository
 {
-    private readonly DbContext _db;
-    public UserReadRepository(DbContext db) => _db = db;
+    private readonly AppDbContext _db;
+    public UserReadRepository(AppDbContext db) => _db = db;
 
     public Task<int> CountActiveAsync(CancellationToken ct)
     {

--- a/src/BoardMgmt.Infrastructure/Persistence/Repositories/VoteReadRepository.cs
+++ b/src/BoardMgmt.Infrastructure/Persistence/Repositories/VoteReadRepository.cs
@@ -2,13 +2,14 @@
 using BoardMgmt.Application.Dashboard.DTOs;
 using BoardMgmt.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
+using BoardMgmt.Infrastructure.Persistence;
 
 namespace BoardMgmt.Infrastructure.Persistence.Repositories;
 
 public class VoteReadRepository : IVoteReadRepository
 {
-    private readonly DbContext _db;
-    public VoteReadRepository(DbContext db) => _db = db;
+    private readonly AppDbContext _db;
+    public VoteReadRepository(AppDbContext db) => _db = db;
 
     // "Pending" = polls whose window is still open (deadline in the future)
     public Task<int> CountPendingAsync(CancellationToken ct)


### PR DESCRIPTION
## Summary
- ensure read repositories depend on the concrete AppDbContext so they can be constructed by DI
- add the corresponding AppDbContext using directives to the read repositories

## Testing
- dotnet build BoardMgmt.sln *(fails: `dotnet` command not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e764233a148320a69b503f3a336091