### PR TITLE
Allow calendar services to cancel events with provider context

### DIFF
--- a/src/BoardMgmt.Application/Calendars/ICalendarService.cs
+++ b/src/BoardMgmt.Application/Calendars/ICalendarService.cs
@@ -7,7 +7,7 @@ public interface ICalendarService
     Task<(string eventId, string? joinUrl)> CreateEventAsync(Meeting meeting, CancellationToken ct = default);
     Task<(bool ok, string? joinUrl)> UpdateEventAsync(Meeting meeting, CancellationToken ct = default);
 
-    Task CancelEventAsync(string eventId, CancellationToken ct = default);
+    Task CancelEventAsync(Meeting meeting, CancellationToken ct = default);
 
     Task<IReadOnlyList<CalendarEventDto>> ListUpcomingAsync(int take = 20, CancellationToken ct = default);
 

--- a/src/BoardMgmt.Application/Meetings/Commands/DeleteMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/DeleteMeetingHandler.cs
@@ -27,7 +27,7 @@ namespace BoardMgmt.Application.Meetings.Commands
                 !string.IsNullOrWhiteSpace(entity.ExternalEventId))
             {
                 var svc = _calSelector.For(entity.ExternalCalendar);
-                await svc.CancelEventAsync(entity.ExternalEventId, ct); // ✅ correct method
+                await svc.CancelEventAsync(entity, ct);
             }
 
             _db.Meetings.Remove(entity);


### PR DESCRIPTION
## Summary
- change `ICalendarService.CancelEventAsync` to receive the full meeting so providers have access to host metadata
- update the Microsoft 365 and Zoom calendar services to honor the meeting mailbox when cancelling events
- adjust the meeting deletion flow to pass the meeting entity through the selector

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e768ac7bf88320926b62090ef86109