### PR TITLE
Add fallback host identity for Teams transcripts

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -66,10 +66,13 @@ namespace BoardMgmt.Application.Meetings.Commands
         // --------------------------------------------------------------------
         private async Task<int> IngestTeams(Meeting meeting, CancellationToken ct)
         {
-            var mailbox = meeting.ExternalCalendarMailbox;
+            var mailbox = string.IsNullOrWhiteSpace(meeting.ExternalCalendarMailbox)
+                ? _app.MailboxAddress
+                : meeting.ExternalCalendarMailbox;
+
             if (string.IsNullOrWhiteSpace(mailbox))
                 throw new InvalidOperationException(
-                    "Meeting.ExternalCalendarMailbox is required for Teams transcript ingestion (set HostIdentity when creating the meeting).");
+                    "Meeting.ExternalCalendarMailbox is required for Teams transcript ingestion. Set HostIdentity when creating the meeting or configure App:MailboxAddress.");
 
             // List transcripts (ONLINE MEETING scope)
             var list = await _graph.Users[mailbox]


### PR DESCRIPTION
## Summary
- default Microsoft 365 meetings to use the configured mailbox when no host identity is provided
- fall back to the same mailbox when ingesting Teams transcripts so the workflow mirrors Zoom

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e776fda7f48320acda781ffd9de72e