### PR TITLE
Fix Teams transcript ingestion for Microsoft Graph v5

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -106,19 +106,18 @@ namespace BoardMgmt.Application.Meetings.Commands
 
             try
             {
-                var onlineMeeting = await _graph.Users[mailbox]
+                var graphEvent = await _graph.Users[mailbox]
                     .Events[meeting.ExternalEventId]
-                    .OnlineMeeting
                     .GetAsync(cfg =>
                     {
-                        cfg.QueryParameters.Select = new[] { "id" };
+                        cfg.QueryParameters.Select = new[] { "onlineMeeting" };
                     }, ct);
 
-                var id = onlineMeeting?.Id;
+                var id = graphEvent?.OnlineMeeting?.Id;
                 if (!string.IsNullOrWhiteSpace(id))
                     return id!;
             }
-            catch (ServiceException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            catch (ServiceException ex) when (ex.ResponseStatusCode == (int)HttpStatusCode.NotFound)
             {
                 throw new InvalidOperationException("Teams meeting not found when resolving online meeting id. Verify the mailbox and meeting id.", ex);
             }


### PR DESCRIPTION
## Summary
- retrieve the Teams online meeting id by reading the event with the onlineMeeting projection
- update ServiceException handling to use the new ResponseStatusCode property

## Testing
- not run (dotnet CLI unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e7823110ac8320a07874d355f4f74e