### PR TITLE
Fix Teams transcript meeting id lookup

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -110,10 +110,10 @@ namespace BoardMgmt.Application.Meetings.Commands
                     .Events[meeting.ExternalEventId]
                     .GetAsync(cfg =>
                     {
-                        cfg.QueryParameters.Select = new[] { "onlineMeeting" };
+                        cfg.QueryParameters.Select = new[] { "onlineMeeting", "onlineMeetingId" };
                     }, ct);
 
-                var id = graphEvent?.OnlineMeeting?.Id;
+                var id = graphEvent?.OnlineMeetingId;
                 if (!string.IsNullOrWhiteSpace(id))
                     return id!;
             }


### PR DESCRIPTION
## Summary
- request the online meeting id when resolving Teams transcripts
- use the event's OnlineMeetingId instead of the removed OnlineMeeting.Id property

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e784448cf08320b41a9419c569d673