### PR TITLE
Fix Microsoft Graph meeting lookup and harden Zoom transcript parsing

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/CreateMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/CreateMeetingHandler.cs
@@ -28,7 +28,7 @@ public class CreateMeetingHandler : IRequestHandler<CreateMeetingCommand, Guid>
     public async Task<Guid> Handle(CreateMeetingCommand request, CancellationToken ct)
     {
         if (!CalendarProviders.IsSupported(request.Provider))
-            throw new ArgumentOutOfRangeException("provider", $"Unknown calendar provider: {request.Provider}");
+            throw new ArgumentOutOfRangeException(nameof(request.Provider), $"Unknown calendar provider: {request.Provider}");
 
 
         var entity = new Meeting


### PR DESCRIPTION
## Summary
- retrieve the Teams online meeting id using the Graph SDK v5 onlineMeeting navigation property
- guard Zoom transcript ingestion helpers against empty HTTP responses and improve error reporting
- fix the ArgumentOutOfRangeException parameter name in CreateMeetingHandler

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e78567ab3883209359c61f0d99dcd4