### PR TITLE
Fix Teams join URL retrieval by expanding onlineMeeting data

### DIFF
--- a/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
+++ b/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
@@ -115,7 +115,7 @@ public sealed class Microsoft365CalendarService : ICalendarService
             cfg.QueryParameters.Top = take;
             cfg.QueryParameters.Orderby = new[] { "start/dateTime" };
             cfg.QueryParameters.Select = new[] { "id", "subject", "start", "end", "onlineMeeting" };
-            // no Expand
+            cfg.QueryParameters.Expand = new[] { "onlineMeeting" };
         }, ct);
 
         var list = resp?.Value ?? new List<Event>();
@@ -138,7 +138,7 @@ public sealed class Microsoft365CalendarService : ICalendarService
             cfg.QueryParameters.Orderby = new[] { "start/dateTime" };
             cfg.QueryParameters.Top = 100;
             cfg.QueryParameters.Select = new[] { "id", "subject", "start", "end", "onlineMeeting" };
-            // no Expand
+            cfg.QueryParameters.Expand = new[] { "onlineMeeting" };
         }, ct);
 
         var list = resp?.Value ?? new List<Event>();
@@ -163,6 +163,7 @@ public sealed class Microsoft365CalendarService : ICalendarService
         var ev = await _graph.Users[mailbox].Events[eventId].GetAsync(cfg =>
         {
             cfg.QueryParameters.Select = new[] { "onlineMeeting" };
+            cfg.QueryParameters.Expand = new[] { "onlineMeeting" };
         }, ct);
 
         return ev?.OnlineMeeting?.JoinUrl;


### PR DESCRIPTION
## Summary
- expand Microsoft 365 calendar queries to include the onlineMeeting resource so join URLs are populated
- ensure the Teams join URL lookup also expands onlineMeeting when refetching events

## Testing
- dotnet build *(fails: command not found: dotnet in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e78b1f0ddc8320bf715966af6b7839