### PR TITLE
Fix Microsoft Graph onlineMeeting queries

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -110,7 +110,6 @@ namespace BoardMgmt.Application.Meetings.Commands
                     .Events[meeting.ExternalEventId]
                     .GetAsync(cfg =>
                     {
-                        cfg.QueryParameters.Expand = new[] { "onlineMeeting" };
                         cfg.QueryParameters.Select = new[] { "onlineMeeting" };
                     }, ct);
 

--- a/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
+++ b/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
@@ -187,7 +187,6 @@ public sealed class Microsoft365CalendarService : ICalendarService
                 () => _graph.Users[mailbox].Events[eventId].GetAsync(cfg =>
                 {
                     cfg.QueryParameters.Select = new[] { "onlineMeeting" };
-                    cfg.QueryParameters.Expand = new[] { "onlineMeeting" };
                 }, ct),
                 "GET /users/{mailbox}/events/{id}?$select=onlineMeeting", ct);
 
@@ -213,7 +212,6 @@ public sealed class Microsoft365CalendarService : ICalendarService
                     .GetAsync(cfg =>
                     {
                         cfg.QueryParameters.Select = new[] { "onlineMeeting" };
-                        cfg.QueryParameters.Expand = new[] { "onlineMeeting" };
                     }, ct);
 
                 onlineMeetingId = ev?.OnlineMeeting?.ConferenceId;


### PR DESCRIPTION
## Summary
- remove unsupported `$expand=onlineMeeting` usage when refetching Microsoft 365 events
- rely on `$select=onlineMeeting` to load Teams meeting details after create/update and during transcript ingestion

## Testing
- not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e7fa63b45483208e7594825ca2345f