### PR TITLE
Add structured login handler logging

### DIFF
--- a/src/BoardMgmt.Application/Users/Commands/Login/LoginCommandHandler.cs
+++ b/src/BoardMgmt.Application/Users/Commands/Login/LoginCommandHandler.cs
@@ -1,8 +1,9 @@
-﻿// backend/src/BoardMgmt.Application/Users/Commands/Login/LoginCommandHandler.cs
+// backend/src/BoardMgmt.Application/Users/Commands/Login/LoginCommandHandler.cs
 using System.Security.Claims;
 using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Domain.Identity;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace BoardMgmt.Application.Users.Commands.Login;
 
@@ -10,16 +11,21 @@ public class LoginCommandHandler(
     IIdentityService identityService,
     IJwtTokenService jwtTokenService,
     IRoleService roleService,
-    IRolePermissionStore rolePermissionStore // 👈 add this
+    IRolePermissionStore rolePermissionStore, // 👈 add this
+    ILogger<LoginCommandHandler> logger
 ) : IRequestHandler<LoginCommand, LoginResponse>
 {
     private const string PermissionClaimType = "permission"; // 👈 handler expects this
+    private readonly ILogger<LoginCommandHandler> _logger = logger;
 
     public async Task<LoginResponse> Handle(LoginCommand request, CancellationToken ct)
     {
+        _logger.LogInformation("Login attempt received for {Email}", request.Email);
+
         var user = await identityService.FindUserByEmailAsync(request.Email);
         if (user is null)
         {
+            _logger.LogWarning("Login failed: user with email {Email} not found", request.Email);
             return new LoginResponse(
                 string.Empty, string.Empty, request.Email, string.Empty,
                 false, new[] { "Invalid email or password." });
@@ -28,6 +34,7 @@ public class LoginCommandHandler(
         var passwordValid = await identityService.CheckPasswordAsync(user, request.Password);
         if (!passwordValid)
         {
+            _logger.LogWarning("Login failed: invalid credentials supplied for {Email}", request.Email);
             return new LoginResponse(
                 string.Empty, string.Empty, request.Email, string.Empty,
                 false, new[] { "Invalid email or password." });
@@ -35,6 +42,11 @@ public class LoginCommandHandler(
 
         // Roles (names) for token
         var roleNames = (await identityService.GetUserRolesAsync(user)).ToList();
+
+        if (roleNames.Count == 0)
+        {
+            _logger.LogInformation("User {Email} authenticated without any assigned roles", request.Email);
+        }
 
         // ===== Aggregate permissions across ALL roles =====
         var roleIds = new List<string>();
@@ -73,6 +85,8 @@ public class LoginCommandHandler(
         }
 
         var token = jwtTokenService.CreateToken(user.Id, user.Email!, roleNames, extraClaims);
+
+        _logger.LogInformation("Login succeeded for {Email} with UserId {UserId}", request.Email, user.Id);
 
         return new LoginResponse(
             token,


### PR DESCRIPTION
## Summary
- add structured logging to the login command handler so authentication attempts and outcomes are captured

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e8b17652608320ad6715e13c767951