### PR TITLE
Reduce noise from framework logging in Serilog sink

### DIFF
--- a/src/BoardMgmt.WebApi/appsettings.json
+++ b/src/BoardMgmt.WebApi/appsettings.json
@@ -20,9 +20,10 @@
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
-        "Microsoft": "Information",
-        "Microsoft.EntityFrameworkCore.Database.Command": "Information",
-        "Microsoft.EntityFrameworkCore.Update": "Information"
+        "Microsoft": "Warning",
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+        "Microsoft.EntityFrameworkCore.Update": "Warning"
       }
     },
     "WriteTo": [


### PR DESCRIPTION
## Summary
- reduce Serilog log noise written to SQL by raising Microsoft and EF Core categories to Warning level

## Testing
- `dotnet build` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e8b3ca25ec8320934962661b96fe5a