### PR TITLE
Fix HttpStatusCode comparison

### DIFF
--- a/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
+++ b/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
@@ -389,7 +389,7 @@ public sealed class Microsoft365CalendarService : ICalendarService
 
     private static bool IsOnlineMeetingExpandUnsupported(ApiException ex)
     {
-        if (ex.ResponseStatusCode != HttpStatusCode.BadRequest)
+        if (ex.ResponseStatusCode != (int)HttpStatusCode.BadRequest)
             return false;
 
         return ex.Message?.Contains("Only navigation properties can be expanded", StringComparison.OrdinalIgnoreCase) == true


### PR DESCRIPTION
## Summary
- cast the Microsoft Graph API exception status code to int before comparing it to HttpStatusCode.BadRequest

## Testing
- not run (dotnet CLI not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e8bc1c412c832099f220530db18342