### PR TITLE
Fix nullability warnings across services

### DIFF
--- a/src/BoardMgmt.Application/Votes/DTOs/VoteDtos.cs
+++ b/src/BoardMgmt.Application/Votes/DTOs/VoteDtos.cs
@@ -29,7 +29,7 @@ public sealed record VoteSummaryDto(
 // New: per-user vote row (populate only when not Anonymous and caller authorized)
 public sealed record IndividualVoteDto(
     string UserId,
-    string DisplayName,
+    string? DisplayName,
     string? ChoiceLabel,   // "Yes" | "No" | "Abstain" for Y/N/Abstain polls
     string? OptionText,    // filled for MultipleChoice
     DateTimeOffset VotedAt

--- a/src/BoardMgmt.Application/Votes/Queries/GetVoteQuery.cs
+++ b/src/BoardMgmt.Application/Votes/Queries/GetVoteQuery.cs
@@ -17,7 +17,8 @@ public sealed class GetVoteQueryHandler(IAppDbContext db, ICurrentUser user)
             .Include(x => x.Options)
             .Include(x => x.Ballots)
             .Include(x => x.EligibleUsers)
-            .Include(x => x.Meeting)!.ThenInclude(m => m.Attendees)
+            .Include(x => x.Meeting)
+                .ThenInclude(m => m.Attendees)
             .AsNoTracking()
             .FirstOrDefaultAsync(x => x.Id == request.Id, ct);
 

--- a/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
+++ b/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
@@ -64,7 +64,7 @@ public sealed class Microsoft365CalendarService : ICalendarService
         };
 
         // Create
-        var created = await RunGraph<Event?>(
+        var created = await RunGraph<Event>(
             () => _graph.Users[mailbox].Events.PostAsync(ev, cancellationToken: ct),
             "POST /users/{mailbox}/events", ct);
 
@@ -143,7 +143,7 @@ public sealed class Microsoft365CalendarService : ICalendarService
     {
         var now = DateTimeOffset.UtcNow;
 
-        var resp = await RunGraph<EventCollectionResponse?>(
+        var resp = await RunGraph<EventCollectionResponse>(
             () => _graph.Users[_opts.MailboxAddress].CalendarView.GetAsync(cfg =>
             {
                 cfg.QueryParameters.StartDateTime = now.ToString("o");
@@ -167,7 +167,7 @@ public sealed class Microsoft365CalendarService : ICalendarService
 
     public async Task<IReadOnlyList<CalendarEventDto>> ListRangeAsync(DateTimeOffset startUtc, DateTimeOffset endUtc, CancellationToken ct = default)
     {
-        var resp = await RunGraph<EventCollectionResponse?>(
+        var resp = await RunGraph<EventCollectionResponse>(
             () => _graph.Users[_opts.MailboxAddress].CalendarView.GetAsync(cfg =>
             {
                 cfg.QueryParameters.StartDateTime = startUtc.ToString("o");
@@ -209,7 +209,7 @@ public sealed class Microsoft365CalendarService : ICalendarService
 
             try
             {
-                fetched = await RunGraph<Event?>(
+                fetched = await RunGraph<Event>(
                     () => _graph.Users[mailbox].Events[eventId].GetAsync(cfg =>
                     {
                         cfg.QueryParameters.Select = new[] { "onlineMeeting", "onlineMeetingUrl" };
@@ -480,7 +480,7 @@ public sealed class Microsoft365CalendarService : ICalendarService
 
     private async Task<string?> TryExtractJoinUrlFromBodyAsync(string mailbox, string eventId, CancellationToken ct)
     {
-        var ev = await RunGraph<Event?>(
+        var ev = await RunGraph<Event>(
             () => _graph.Users[mailbox].Events[eventId].GetAsync(cfg =>
             {
                 cfg.QueryParameters.Select = new[] { "body" };

--- a/src/BoardMgmt.WebApi/Common/Http/ApiResponses.cs
+++ b/src/BoardMgmt.WebApi/Common/Http/ApiResponses.cs
@@ -10,7 +10,7 @@ public record ApiResponse<T>(
     DateTimeOffset Timestamp
 )
 {
-    public static ApiResponse<T> Ok(T data, string? message, string traceId) =>
+    public static ApiResponse<T> Ok(T? data, string? message, string traceId) =>
         new(true, data, message, traceId, DateTimeOffset.UtcNow);
 }
 

--- a/src/BoardMgmt.WebApi/Controllers/ZoomWebhookController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/ZoomWebhookController.cs
@@ -57,6 +57,12 @@ namespace BoardMgmt.WebApi.Controllers
                     Request.Headers["x-zm-request-timestamp"].ToString(),
                     Request.Headers["x-zm-signature"].ToString());
 
+                if (string.IsNullOrWhiteSpace(body))
+                {
+                    _logger.LogWarning("Zoom webhook received empty body.");
+                    return BadRequest("empty body");
+                }
+
                 using var doc = JsonDocument.Parse(body);
                 var root = doc.RootElement;
 


### PR DESCRIPTION
## Summary
- relax IndividualVoteDto and vote query to avoid null-reference warnings when display names are supplied later
- align Microsoft365CalendarService RunGraph calls and API response helper with nullable expectations
- guard the Zoom webhook controller against empty payloads before parsing JSON

## Testing
- dotnet build *(fails: dotnet SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e9e9c0f01c8320bff2b2ef6668b294