### PR TITLE
Handle null user IDs in vote flows

### DIFF
--- a/src/BoardMgmt.Application/Votes/Commands/SubmitBallotCommand.cs
+++ b/src/BoardMgmt.Application/Votes/Commands/SubmitBallotCommand.cs
@@ -22,6 +22,8 @@ public sealed class SubmitBallotCommandHandler
     {
         if (!_user.IsAuthenticated) throw new UnauthorizedAccessException();
 
+        var userId = _user.UserId ?? throw new InvalidOperationException("Authenticated user missing identifier.");
+
         var v = await _db.VotePolls
             .Include(x => x.Options)
             .Include(x => x.Ballots) // needed to find/update the user's ballot + recompute results
@@ -37,8 +39,8 @@ public sealed class SubmitBallotCommandHandler
         var eligible = v.Eligibility switch
         {
             VoteEligibility.Public => true,
-            VoteEligibility.SpecificUsers => v.EligibleUsers.Any(e => e.UserId == _user.UserId),
-            VoteEligibility.MeetingAttendees => v.MeetingId != null && v.Meeting!.Attendees.Any(a => a.UserId == _user.UserId),
+            VoteEligibility.SpecificUsers => v.EligibleUsers.Any(e => e.UserId == userId),
+            VoteEligibility.MeetingAttendees => v.MeetingId != null && v.Meeting!.Attendees.Any(a => a.UserId == userId),
             _ => false
         };
         if (!eligible) throw new UnauthorizedAccessException("Not eligible to vote.");
@@ -57,10 +59,10 @@ public sealed class SubmitBallotCommandHandler
         }
 
         // ✅ Upsert the user's ballot (create if none, otherwise UPDATE to allow re-voting)
-        var ballot = v.Ballots.FirstOrDefault(b => b.UserId == _user.UserId);
+        var ballot = v.Ballots.FirstOrDefault(b => b.UserId == userId);
         if (ballot is null)
         {
-            ballot = new VoteBallot { VoteId = v.Id, UserId = _user.UserId! };
+            ballot = new VoteBallot { VoteId = v.Id, UserId = userId };
             _db.VoteBallots.Add(ballot);
         }
 


### PR DESCRIPTION
## Summary
- guard vote eligibility filtering against authenticated users without IDs
- ensure submit ballot requires a current user identifier before proceeding
- prevent null user IDs from being used when checking existing ballots

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e9ec54942483209825952d4274a8b1