### PR TITLE
Fix nullable warnings in vote queries

### DIFF
--- a/src/BoardMgmt.Application/Votes/Commands/SubmitBallotCommand.cs
+++ b/src/BoardMgmt.Application/Votes/Commands/SubmitBallotCommand.cs
@@ -28,7 +28,8 @@ public sealed class SubmitBallotCommandHandler
             .Include(x => x.Options)
             .Include(x => x.Ballots) // needed to find/update the user's ballot + recompute results
             .Include(x => x.EligibleUsers)
-            .Include(x => x.Meeting)!.ThenInclude(m => m.Attendees)
+            .Include(x => x.Meeting)
+                .ThenInclude(m => m.Attendees)
             .FirstOrDefaultAsync(x => x.Id == r.VoteId, ct)
             ?? throw new KeyNotFoundException("Vote not found.");
 
@@ -40,7 +41,8 @@ public sealed class SubmitBallotCommandHandler
         {
             VoteEligibility.Public => true,
             VoteEligibility.SpecificUsers => v.EligibleUsers.Any(e => e.UserId == userId),
-            VoteEligibility.MeetingAttendees => v.MeetingId != null && v.Meeting!.Attendees.Any(a => a.UserId == userId),
+            VoteEligibility.MeetingAttendees => v.MeetingId != null && v.Meeting != null &&
+                v.Meeting.Attendees.Any(a => a.UserId == userId),
             _ => false
         };
         if (!eligible) throw new UnauthorizedAccessException("Not eligible to vote.");

--- a/src/BoardMgmt.Application/Votes/Queries/GetVoteQuery.cs
+++ b/src/BoardMgmt.Application/Votes/Queries/GetVoteQuery.cs
@@ -42,7 +42,7 @@ public sealed class GetVoteQueryHandler(IAppDbContext db, ICurrentUser user)
 
         var uid = user.UserId;
         var isAuthed = user.IsAuthenticated && !string.IsNullOrEmpty(uid);
-        var authedUserId = isAuthed ? uid! : null;
+        var authedUserId = isAuthed ? uid : null;
 
         bool eligible = v.Eligibility switch
         {


### PR DESCRIPTION
## Summary
- guard vote handlers against missing navigation entities when evaluating eligibility
- avoid null-forgiving operators when reading the current user identifier

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e9ed533ec88320933d3e7b8497e0f2