### PR TITLE
Ensure Teams meetings record mailbox for transcript ingest

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/CreateMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/CreateMeetingHandler.cs
@@ -41,7 +41,8 @@ public class CreateMeetingHandler : IRequestHandler<CreateMeetingCommand, Guid>
             Location = string.IsNullOrWhiteSpace(request.Location) ? "TBD" : request.Location.Trim(),
             Status = MeetingStatus.Scheduled,
             ExternalCalendar = request.Provider, // "Microsoft365" or "Zoom"
-            ExternalCalendarMailbox = request.HostIdentity // M365 mailbox or Zoom host email (optional)
+            ExternalCalendarMailbox = request.HostIdentity, // M365 mailbox or Zoom host email (optional)
+            HostIdentity = request.HostIdentity
         };
 
 

--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -69,10 +69,15 @@ namespace BoardMgmt.Application.Meetings.Commands
         // --------------------------------------------------------------------
         private async Task<int> IngestTeams(Meeting meeting, CancellationToken ct)
         {
-            var mailbox = meeting.ExternalCalendarMailbox;
+            var mailbox = !string.IsNullOrWhiteSpace(meeting.ExternalCalendarMailbox)
+                ? meeting.ExternalCalendarMailbox
+                : !string.IsNullOrWhiteSpace(meeting.HostIdentity)
+                    ? meeting.HostIdentity
+                    : _app.MailboxAddress;
+
             if (string.IsNullOrWhiteSpace(mailbox))
                 throw new InvalidOperationException(
-                    "Meeting.ExternalCalendarMailbox is required for Teams transcript ingestion (set HostIdentity when creating the meeting).");
+                    "Meeting.ExternalCalendarMailbox is required for Teams transcript ingestion (set HostIdentity when creating the meeting or configure a default mailbox).");
 
             var onlineMeetingId = await ResolveTeamsOnlineMeetingIdAsync(mailbox!, meeting, ct);
 


### PR DESCRIPTION
## Summary
- persist the mailbox used when creating or updating Microsoft 365 meetings so transcript ingestion can resolve the Teams event
- fall back to the stored host identity or configured default when ingesting transcripts if the mailbox was not previously saved
- store the requested host identity alongside the meeting record for future lookups

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e9f0d730b083209258c30b1950fa84