### PR TITLE
Increase Zoom HTTP timeout

### DIFF
--- a/src/BoardMgmt.Infrastructure/DependencyInjection.cs
+++ b/src/BoardMgmt.Infrastructure/DependencyInjection.cs
@@ -162,7 +162,7 @@ namespace BoardMgmt.Infrastructure
             services.AddHttpClient("Zoom", client =>
             {
                 client.BaseAddress = new Uri("https://api.zoom.us/v2/");
-                client.Timeout = TimeSpan.FromSeconds(30);
+                client.Timeout = TimeSpan.FromMinutes(5);
                 // BaseAddress optional; we send absolute URLs.
             });
 


### PR DESCRIPTION
## Summary
- increase the configured timeout for the Zoom HttpClient to allow longer transcript downloads

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ea001a81b083208eaf0618a7867cad