### PR TITLE
Handle invalid operations in API middleware

### DIFF
--- a/src/BoardMgmt.WebApi/Common/Http/ExceptionHandlingMiddleware.cs
+++ b/src/BoardMgmt.WebApi/Common/Http/ExceptionHandlingMiddleware.cs
@@ -69,6 +69,13 @@ public class ExceptionHandlingMiddleware : IMiddleware
                 new { dbex.InnerException?.Message }
             ),
 
+            InvalidOperationException ioex => (
+                StatusCodes.Status400BadRequest,
+                "invalid_operation",
+                ioex.Message,
+                null
+            ),
+
             _ => (
                 StatusCodes.Status500InternalServerError,
                 "server_error",


### PR DESCRIPTION
## Summary
- return HTTP 400 responses for InvalidOperationException so business validation errors are surfaced to clients

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea9c78d10083209c737c4540ef7d5c