### PR TITLE
Handle transcript utterance replacement without duplicate tracking

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -1023,8 +1023,11 @@ namespace BoardMgmt.Application.Meetings.Commands
 
             if (existing != null)
             {
-                _db.Set<TranscriptUtterance>().RemoveRange(
-                    _db.Set<TranscriptUtterance>().Where(u => u.TranscriptId == existing.Id));
+                if (existing.Utterances.Count > 0)
+                {
+                    _db.Set<TranscriptUtterance>().RemoveRange(existing.Utterances);
+                    existing.Utterances.Clear();
+                }
 
                 existing.ProviderTranscriptId = providerTranscriptId;
                 existing.CreatedUtc = DateTimeOffset.UtcNow;


### PR DESCRIPTION
## Summary
- clear existing transcript utterances by deleting the tracked collection before recreating it
- avoid duplicate tracked entities when re-ingesting transcripts to prevent EF concurrency errors

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb267f5a70832082592d591b418936