### PR TITLE
Align EF Core package versions to 8.0.8

### DIFF
--- a/src/BoardMgmt.Application/BoardMgmt.Application.csproj
+++ b/src/BoardMgmt.Application/BoardMgmt.Application.csproj
@@ -11,6 +11,6 @@
 		<PackageReference Include="FluentValidation" Version="11.9.0" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
 		<PackageReference Include="MediatR" Version="12.2.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
 	</ItemGroup>
 </Project>

--- a/src/BoardMgmt.Domain/BoardMgmt.Domain.csproj
+++ b/src/BoardMgmt.Domain/BoardMgmt.Domain.csproj
@@ -12,7 +12,7 @@
         </ItemGroup>
 
         <ItemGroup>
-          <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.0" />
+          <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.8" />
         </ItemGroup>
 
 </Project>

--- a/src/BoardMgmt.Infrastructure/BoardMgmt.Infrastructure.csproj
+++ b/src/BoardMgmt.Infrastructure/BoardMgmt.Infrastructure.csproj
@@ -8,9 +8,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Identity" Version="1.*" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.8" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BoardMgmt.WebApi/BoardMgmt.WebApi.csproj
+++ b/src/BoardMgmt.WebApi/BoardMgmt.WebApi.csproj
@@ -10,7 +10,7 @@
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
 		<PackageReference Include="MediatR" Version="12.2.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- update all EF Core-related package references to version 8.0.8 across the application, infrastructure, domain, and web projects to resolve downgrade errors

## Testing
- dotnet build *(fails: .NET SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb3cf6bf6883209a15aeb10828fe7c