### PR TITLE
Handle transcript ingestion concurrency conflicts

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -104,21 +104,29 @@ namespace BoardMgmt.Application.Meetings.Commands
             try
             {
                 var existing = await _db.Set<Transcript>()
-                    .Include(t => t.Utterances)
                     .FirstOrDefaultAsync(t => t.MeetingId == meeting.Id && t.Provider == provider, ct);
 
                 if (existing != null)
                 {
-                    if (existing.Utterances.Count > 0)
+                    if (_db is DbContext dbContext)
                     {
-
-                        _logger.LogWarning("if", existing.Utterances.Count);
-                        // EF Core 6.x does not support ExecuteDeleteAsync, so remove the tracked entities manually.
-                        _db.Set<TranscriptUtterance>().RemoveRange(existing.Utterances);
-                        _logger.LogWarning("if 2");
-                        existing.Utterances.Clear();
-                        _logger.LogWarning("if 3");
+                        await dbContext.Set<TranscriptUtterance>()
+                            .Where(u => u.TranscriptId == existing.Id)
+                            .ExecuteDeleteAsync(ct);
                     }
+                    else
+                    {
+                        var existingUtterances = await _db.Set<TranscriptUtterance>()
+                            .Where(u => u.TranscriptId == existing.Id)
+                            .ToListAsync(ct);
+
+                        if (existingUtterances.Count > 0)
+                        {
+                            _db.Set<TranscriptUtterance>().RemoveRange(existingUtterances);
+                        }
+                    }
+
+                    existing.Utterances.Clear();
 
                     existing.ProviderTranscriptId = providerTranscriptId;
                     existing.CreatedUtc = DateTimeOffset.UtcNow;


### PR DESCRIPTION
## Summary
- replace the tracked per-entity deletion of transcript utterances with a set-based delete to avoid concurrency conflicts during retries
- retain a fallback path for non-EF contexts while clearing the in-memory collection before rebuilding the utterances

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68eb40b2768c8320ad892da870c24c0b