### PR TITLE
Replace ExecuteDeleteAsync usage for EF Core compatibility

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -196,14 +196,19 @@ namespace BoardMgmt.Application.Meetings.Commands
         {
             if (_db is DbContext dbContext)
             {
-                await dbContext.Set<TranscriptUtterance>()
+                var existingUtterances = await dbContext.Set<TranscriptUtterance>()
                     .Where(u => u.TranscriptId == transcript.Id)
-                    .ExecuteDeleteAsync(ct);
+                    .ToListAsync(ct);
 
-                foreach (var entry in dbContext.ChangeTracker.Entries<TranscriptUtterance>()
-                             .Where(e => e.Entity.TranscriptId == transcript.Id))
+                if (existingUtterances.Count > 0)
                 {
-                    entry.State = EntityState.Detached;
+                    dbContext.Set<TranscriptUtterance>().RemoveRange(existingUtterances);
+
+                    foreach (var entry in dbContext.ChangeTracker.Entries<TranscriptUtterance>()
+                                 .Where(e => e.Entity.TranscriptId == transcript.Id))
+                    {
+                        entry.State = EntityState.Detached;
+                    }
                 }
             }
             else


### PR DESCRIPTION
## Summary
- replace ExecuteDeleteAsync usage in transcript ingestion to use RemoveRange for compatibility with EF Core versions that do not support ExecuteDeleteAsync

## Testing
- dotnet run --project src/BoardMgmt.Api --urls "http://localhost:5285" *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb4545b80083209dc1d682a8fcccf4