### PR TITLE
Handle transcript utterance deletions without concurrency conflicts

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -196,19 +196,14 @@ namespace BoardMgmt.Application.Meetings.Commands
         {
             if (_db is DbContext dbContext)
             {
-                var existingUtterances = await dbContext.Set<TranscriptUtterance>()
+                await dbContext.Set<TranscriptUtterance>()
                     .Where(u => u.TranscriptId == transcript.Id)
-                    .ToListAsync(ct);
+                    .ExecuteDeleteAsync(ct);
 
-                if (existingUtterances.Count > 0)
+                foreach (var entry in dbContext.ChangeTracker.Entries<TranscriptUtterance>()
+                             .Where(e => e.Entity.TranscriptId == transcript.Id))
                 {
-                    dbContext.Set<TranscriptUtterance>().RemoveRange(existingUtterances);
-
-                    foreach (var entry in dbContext.ChangeTracker.Entries<TranscriptUtterance>()
-                                 .Where(e => e.Entity.TranscriptId == transcript.Id))
-                    {
-                        entry.State = EntityState.Detached;
-                    }
+                    entry.State = EntityState.Detached;
                 }
             }
             else


### PR DESCRIPTION
## Summary
- replace per-entity removal of transcript utterances with a set-based ExecuteDeleteAsync call
- detach any lingering utterance entries after the bulk delete so retries start with a clean change tracker

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb46ed2058832093a7bef5c6ef0fab