### PR TITLE
Replace ExecuteDeleteAsync with RemoveRange fallback

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -196,9 +196,14 @@ namespace BoardMgmt.Application.Meetings.Commands
         {
             if (_db is DbContext dbContext)
             {
-                await dbContext.Set<TranscriptUtterance>()
+                var utterances = await dbContext.Set<TranscriptUtterance>()
                     .Where(u => u.TranscriptId == transcript.Id)
-                    .ExecuteDeleteAsync(ct);
+                    .ToListAsync(ct);
+
+                if (utterances.Count > 0)
+                {
+                    dbContext.Set<TranscriptUtterance>().RemoveRange(utterances);
+                }
 
                 foreach (var entry in dbContext.ChangeTracker.Entries<TranscriptUtterance>()
                              .Where(e => e.Entity.TranscriptId == transcript.Id))


### PR DESCRIPTION
## Summary
- replace the use of ExecuteDeleteAsync when removing transcript utterances
- fall back to loading and removing tracked entities for compatibility with EF Core versions lacking ExecuteDeleteAsync

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb47da29f08320ac41db5112ee2b31