### PR TITLE
Ensure cascades for meetings and transcripts

### DIFF
--- a/src/BoardMgmt.Domain/Entities/Meeting.cs
+++ b/src/BoardMgmt.Domain/Entities/Meeting.cs
@@ -25,6 +25,8 @@ public class Meeting : AuditableEntity
 
     public List<VotePoll> Votes { get; set; } = new();
 
+    public ICollection<Transcript> Transcripts { get; set; } = new List<Transcript>();
+
     [MaxLength(256)]
     public string? ExternalCalendar { get; set; }
 

--- a/src/BoardMgmt.Infrastructure/Migrations/20251011105232_InitialCreate.Designer.cs
+++ b/src/BoardMgmt.Infrastructure/Migrations/20251011105232_InitialCreate.Designer.cs
@@ -1331,7 +1331,7 @@ namespace BoardMgmt.Infrastructure.Migrations
             modelBuilder.Entity("BoardMgmt.Domain.Entities.Transcript", b =>
                 {
                     b.HasOne("BoardMgmt.Domain.Entities.Meeting", "Meeting")
-                        .WithMany()
+                        .WithMany("Transcripts")
                         .HasForeignKey("MeetingId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -1503,6 +1503,8 @@ namespace BoardMgmt.Infrastructure.Migrations
                     b.Navigation("Attendees");
 
                     b.Navigation("Documents");
+
+                    b.Navigation("Transcripts");
 
                     b.Navigation("Votes");
                 });

--- a/src/BoardMgmt.Infrastructure/Migrations/20251120120000_FixMeetingTranscriptCascade.Designer.cs
+++ b/src/BoardMgmt.Infrastructure/Migrations/20251120120000_FixMeetingTranscriptCascade.Designer.cs
@@ -4,6 +4,7 @@ using BoardMgmt.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BoardMgmt.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251120120000_FixMeetingTranscriptCascade")]
+    partial class FixMeetingTranscriptCascade
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BoardMgmt.Infrastructure/Migrations/20251120120000_FixMeetingTranscriptCascade.cs
+++ b/src/BoardMgmt.Infrastructure/Migrations/20251120120000_FixMeetingTranscriptCascade.cs
@@ -1,0 +1,90 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BoardMgmt.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixMeetingTranscriptCascade : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MeetingAttendees_Meetings_MeetingId",
+                table: "MeetingAttendees");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Transcripts_Meetings_MeetingId",
+                table: "Transcripts");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TranscriptUtterances_Transcripts_TranscriptId",
+                table: "TranscriptUtterances");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MeetingAttendees_Meetings_MeetingId",
+                table: "MeetingAttendees",
+                column: "MeetingId",
+                principalTable: "Meetings",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Transcripts_Meetings_MeetingId",
+                table: "Transcripts",
+                column: "MeetingId",
+                principalTable: "Meetings",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TranscriptUtterances_Transcripts_TranscriptId",
+                table: "TranscriptUtterances",
+                column: "TranscriptId",
+                principalTable: "Transcripts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MeetingAttendees_Meetings_MeetingId",
+                table: "MeetingAttendees");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Transcripts_Meetings_MeetingId",
+                table: "Transcripts");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TranscriptUtterances_Transcripts_TranscriptId",
+                table: "TranscriptUtterances");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MeetingAttendees_Meetings_MeetingId",
+                table: "MeetingAttendees",
+                column: "MeetingId",
+                principalTable: "Meetings",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Transcripts_Meetings_MeetingId",
+                table: "Transcripts",
+                column: "MeetingId",
+                principalTable: "Meetings",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TranscriptUtterances_Transcripts_TranscriptId",
+                table: "TranscriptUtterances",
+                column: "TranscriptId",
+                principalTable: "Transcripts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/src/BoardMgmt.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/BoardMgmt.Infrastructure/Persistence/AppDbContext.cs
@@ -119,6 +119,7 @@ namespace BoardMgmt.Infrastructure.Persistence
                 e.HasMany(m => m.AgendaItems).WithOne().HasForeignKey(ai => ai.MeetingId).OnDelete(DeleteBehavior.Cascade);
                 e.HasMany(m => m.Documents).WithOne().HasForeignKey(d => d.MeetingId).OnDelete(DeleteBehavior.Cascade);
                 e.HasMany(m => m.Attendees).WithOne(a => a.Meeting).HasForeignKey(a => a.MeetingId).OnDelete(DeleteBehavior.Cascade);
+                e.HasMany(m => m.Transcripts).WithOne(t => t.Meeting).HasForeignKey(t => t.MeetingId).OnDelete(DeleteBehavior.Cascade);
 
                 e.HasIndex(m => new { m.ScheduledAt, m.Status });
             });
@@ -398,7 +399,7 @@ namespace BoardMgmt.Infrastructure.Persistence
                 e.HasIndex(x => new { x.MeetingId, x.Provider }).IsUnique();
 
                 e.HasOne(x => x.Meeting)
-                 .WithMany() // or .WithOne()? We are not adding collection on Meeting to keep your entity light
+                 .WithMany(m => m.Transcripts)
                  .HasForeignKey(x => x.MeetingId)
                  .OnDelete(DeleteBehavior.Cascade);
             });


### PR DESCRIPTION
## Summary
- expose a transcripts navigation on Meeting and wire it into the EF configuration
- add a migration to enforce cascading deletes for meetings, transcripts, and transcript utterances
- update the EF Core snapshot files to reflect the cascade behaviour

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68eb4b2899d88320b55a81fac693ae56