### PR TITLE
Retry Teams transcript requests on server errors

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.Teams.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.Teams.cs
@@ -303,6 +303,11 @@ namespace BoardMgmt.Application.Meetings.Commands
             return true;
         }
 
+        if (ex.ResponseStatusCode >= 500 && ex.ResponseStatusCode < 600)
+        {
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
## Summary
- retry Teams transcript list/download requests against the beta Graph endpoint when the v1.0 endpoint returns a server error

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68eb682ea0188320b13c712fe5028a28