### PR TITLE
Use string response when listing Teams transcripts

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.Teams.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.Teams.cs
@@ -108,15 +108,15 @@ namespace BoardMgmt.Application.Meetings.Commands
                     .ToGetRequestInformation(),
                 async requestInfo =>
                 {
-                    await using var stream = await _graph.RequestAdapter.SendPrimitiveAsync<Stream>(
+                    var json = await _graph.RequestAdapter.SendPrimitiveAsync<string>(
                         requestInfo,
                         GraphErrorMapping,
                         cancellationToken: ct);
 
-                    if (stream is null)
+                    if (string.IsNullOrWhiteSpace(json))
                         return null;
 
-                    using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+                    using var doc = JsonDocument.Parse(json);
                     if (!doc.RootElement.TryGetProperty("value", out var valueElement) || valueElement.ValueKind != JsonValueKind.Array)
                         return null;
 


### PR DESCRIPTION
## Summary
- retrieve Teams transcript metadata using a string response rather than a stream
- avoid parsing issues caused by the raw stream when listing Teams transcripts

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68eb8e6310948320bc4b50e0be6d78aa