### PR TITLE
Improve logging when online meeting expand is rejected

### DIFF
--- a/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
+++ b/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
@@ -245,7 +245,11 @@ public sealed class Microsoft365CalendarService : ICalendarService
             catch (ApiException ex) when (tryExpand && IsOnlineMeetingExpandUnsupported(ex))
             {
                 _supportsOnlineMeetingExpand = false;
-                _logger.LogInformation("Microsoft Graph rejected $expand=onlineMeeting; retrying without expand.");
+                _logger.LogInformation(
+                    ex,
+                    "Microsoft Graph rejected $expand=onlineMeeting; retrying without expand. status={Status} message={Message}",
+                    ex.ResponseStatusCode,
+                    ex.Message);
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- include Graph exception context when Microsoft Graph rejects the onlineMeeting expand to aid troubleshooting

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68ec9c88189883208400c00574f7dff6