### PR TITLE
Normalize Microsoft 365 provider handling

### DIFF
--- a/src/BoardMgmt.Application/Calendars/ICalendarService.cs
+++ b/src/BoardMgmt.Application/Calendars/ICalendarService.cs
@@ -1,4 +1,5 @@
-﻿using BoardMgmt.Domain.Entities;
+﻿using BoardMgmt.Domain.Calendars;
+using BoardMgmt.Domain.Entities;
 
 namespace BoardMgmt.Application.Calendars;
 
@@ -21,7 +22,7 @@ public sealed record CalendarEventDto(
     DateTimeOffset StartUtc,
     DateTimeOffset EndUtc,
     string? JoinUrl,
-    string? Provider = "Microsoft365" // default string; services should override with actual provider
+    string? Provider = CalendarProviders.Microsoft365 // default string; services should override with actual provider
 );
 
 

--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.Teams.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.Teams.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using BoardMgmt.Domain.Calendars;
 using BoardMgmt.Domain.Entities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
@@ -107,7 +108,7 @@ namespace BoardMgmt.Application.Meetings.Commands
             if (string.IsNullOrWhiteSpace(vtt))
                 throw new InvalidOperationException("Teams returned an empty transcript content.");
 
-            return await SaveVtt(meeting, "Microsoft365", transcript.Id, vtt, ct);
+            return await SaveVtt(meeting, CalendarProviders.Microsoft365, transcript.Id, vtt, ct);
         }
 
         private async Task<TeamsTranscriptMetadata?> GetTeamsTranscriptMetadataAsync(

--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.Zoom.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.Zoom.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using BoardMgmt.Domain.Calendars;
 using BoardMgmt.Domain.Entities;
 using Microsoft.Extensions.Logging;
 
@@ -149,7 +150,7 @@ namespace BoardMgmt.Application.Meetings.Commands
         if (string.IsNullOrWhiteSpace(vtt))
             throw new InvalidOperationException("Zoom returned an empty transcript content.");
 
-        return await SaveVtt(meeting, "Zoom", fileId, vtt, ct);
+        return await SaveVtt(meeting, CalendarProviders.Zoom, fileId, vtt, ct);
     }
 
     private async Task<string> DownloadZoomTranscriptAsync(HttpClient http, string token, string downloadUrl, CancellationToken ct)

--- a/src/BoardMgmt.Domain/Calendars/CalendarProviders.cs
+++ b/src/BoardMgmt.Domain/Calendars/CalendarProviders.cs
@@ -1,4 +1,7 @@
 ﻿// Domain/Calendars/CalendarProviders.cs
+using System;
+using System.Linq;
+
 namespace BoardMgmt.Domain.Calendars;
 
 
@@ -7,7 +10,38 @@ public static class CalendarProviders
     public const string Microsoft365 = "Microsoft365";
     public const string Zoom = "Zoom";
 
+    private static readonly string[] Microsoft365Aliases =
+    {
+        Microsoft365,
+        "Microsoft 365",
+        "MS365",
+        "MS 365",
+        "Office365",
+        "Office 365",
+        "Teams",
+        "Microsoft Teams"
+    };
 
-    public static bool IsSupported(string? value) =>
-    value is Microsoft365 or Zoom;
+
+    public static string? Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+
+        var trimmed = value.Trim();
+
+        if (Microsoft365Aliases.Any(alias => string.Equals(trimmed, alias, StringComparison.OrdinalIgnoreCase)))
+            return Microsoft365;
+
+        if (string.Equals(trimmed, Zoom, StringComparison.OrdinalIgnoreCase))
+            return Zoom;
+
+        return trimmed;
+    }
+
+
+    public static bool IsSupported(string? value)
+    {
+        var normalized = Normalize(value);
+        return normalized is not null && (normalized == Microsoft365 || normalized == Zoom);
+    }
 }

--- a/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
+++ b/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
@@ -11,6 +11,7 @@ using Microsoft.Graph;
 using Microsoft.Graph.Models;
 using Microsoft.Kiota.Abstractions; // ApiException (Graph v5 / Kiota)
 using BoardMgmt.Application.Calendars;
+using BoardMgmt.Domain.Calendars;
 using BoardMgmt.Domain.Entities;
 
 namespace BoardMgmt.Infrastructure.Calendars;
@@ -177,7 +178,7 @@ public sealed class Microsoft365CalendarService : ICalendarService
             ParseUtc(e.Start),
             ParseUtc(e.End),
             ExtractJoinUrl(e),
-            "Microsoft365"
+            CalendarProviders.Microsoft365
         )).ToList();
     }
 
@@ -201,7 +202,7 @@ public sealed class Microsoft365CalendarService : ICalendarService
             ParseUtc(e.Start),
             ParseUtc(e.End),
             ExtractJoinUrl(e),
-            "Microsoft365"
+            CalendarProviders.Microsoft365
         )).ToList();
     }
 

--- a/src/BoardMgmt.Infrastructure/DependencyInjection.cs
+++ b/src/BoardMgmt.Infrastructure/DependencyInjection.cs
@@ -5,6 +5,7 @@ using BoardMgmt.Application.Common.Email;
 using BoardMgmt.Application.Common.Interfaces;
 using BoardMgmt.Application.Common.Interfaces.Repositories;
 using BoardMgmt.Application.Common.Options;
+using BoardMgmt.Domain.Calendars;
 using BoardMgmt.Domain.Entities;
 using BoardMgmt.Domain.Identity;
 using BoardMgmt.Infrastructure.Auth;
@@ -183,8 +184,8 @@ namespace BoardMgmt.Infrastructure
             // Selector registration (map provider keys to services)
             services.AddSingleton<ICalendarServiceSelector>(sp => new CalendarServiceSelector(new[]
             {
-                new KeyValuePair<string, ICalendarService>("Microsoft365", sp.GetRequiredService<Microsoft365CalendarService>()),
-                new KeyValuePair<string, ICalendarService>("Zoom", sp.GetRequiredService<ZoomCalendarService>())
+                new KeyValuePair<string, ICalendarService>(CalendarProviders.Microsoft365, sp.GetRequiredService<Microsoft365CalendarService>()),
+                new KeyValuePair<string, ICalendarService>(CalendarProviders.Zoom, sp.GetRequiredService<ZoomCalendarService>())
             }));
 
 

--- a/src/BoardMgmt.WebApi/Controllers/CalendarController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/CalendarController.cs
@@ -1,6 +1,7 @@
 ﻿using BoardMgmt.Application.Calendars;
 using BoardMgmt.Application.Calendars.Commands;
 using BoardMgmt.Application.Calendars.Queries;
+using BoardMgmt.Domain.Calendars;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -50,17 +51,19 @@ public sealed class CalendarController : ControllerBase
             }
         }
 
-        if (string.Equals(provider, "Zoom", StringComparison.OrdinalIgnoreCase))
+        var normalizedProvider = CalendarProviders.Normalize(provider);
+
+        if (normalizedProvider == CalendarProviders.Zoom)
         {
-            await Add("Zoom");
+            await Add(CalendarProviders.Zoom);
         }
-        else if (string.Equals(provider, "Microsoft365", StringComparison.OrdinalIgnoreCase))
+        else if (normalizedProvider == CalendarProviders.Microsoft365)
         {
-            await Add("Microsoft365");
+            await Add(CalendarProviders.Microsoft365);
         }
         else // All
         {
-            await Task.WhenAll(Add("Microsoft365"), Add("Zoom"));
+            await Task.WhenAll(Add(CalendarProviders.Microsoft365), Add(CalendarProviders.Zoom));
         }
 
         if (warnings.Count > 0)

--- a/src/BoardMgmt.WebApi/Controllers/MicrosoftGraphWebhookController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/MicrosoftGraphWebhookController.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using BoardMgmt.Application.Meetings.Commands;
 using BoardMgmt.Domain.Entities;
 using BoardMgmt.Application.Common.Interfaces;
+using BoardMgmt.Domain.Calendars;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -155,7 +156,7 @@ namespace BoardMgmt.WebApi.Controllers
             if (!string.IsNullOrWhiteSpace(onlineMeetingId))
             {
                 var found = await _db.Set<Meeting>()
-                    .Where(m => m.ExternalCalendar == "Microsoft365" &&
+                    .Where(m => m.ExternalCalendar == CalendarProviders.Microsoft365 &&
                                 m.ExternalEventId == onlineMeetingId) // <-- add this nullable column if not present
                     .Select(m => m.Id)
                     .FirstOrDefaultAsync(ct);
@@ -167,7 +168,7 @@ namespace BoardMgmt.WebApi.Controllers
             // recent Teams meeting that has not been ingested yet (heuristic).
             // You can improve this by also checking ExternalEventId + mailbox.
             var recent = await _db.Set<Meeting>()
-                .Where(m => m.ExternalCalendar == "Microsoft365" &&
+                .Where(m => m.ExternalCalendar == CalendarProviders.Microsoft365 &&
                             (m.EndAt ?? m.ScheduledAt.AddHours(2)) > DateTimeOffset.UtcNow.AddHours(-12))
                 .OrderByDescending(m => m.ScheduledAt)
                 .Select(m => m.Id)


### PR DESCRIPTION
## Summary
- normalize external calendar provider inputs and reuse shared CalendarProviders constants across the stack
- add Microsoft 365 alias normalization so Teams ingests support common provider variants
- align calendar services, controllers, and DTO defaults with the normalized provider key

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ecdfe7c97883209138b8d11ea98d77