### PR TITLE
Handle Teams mailbox when deleting calendar events

### DIFF
--- a/src/BoardMgmt.Application/Calendars/ICalendarService.cs
+++ b/src/BoardMgmt.Application/Calendars/ICalendarService.cs
@@ -8,7 +8,7 @@ public interface ICalendarService
     Task<(string eventId, string? joinUrl)> CreateEventAsync(Meeting meeting, CancellationToken ct = default);
     Task<(bool ok, string? joinUrl)> UpdateEventAsync(Meeting meeting, CancellationToken ct = default);
 
-    Task CancelEventAsync(string eventId, CancellationToken ct = default);
+    Task CancelEventAsync(string eventId, string? mailbox = null, CancellationToken ct = default);
 
     Task<IReadOnlyList<CalendarEventDto>> ListUpcomingAsync(int take = 20, CancellationToken ct = default);
 

--- a/src/BoardMgmt.Application/Meetings/Commands/DeleteMeetingHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/DeleteMeetingHandler.cs
@@ -27,7 +27,7 @@ namespace BoardMgmt.Application.Meetings.Commands
                 !string.IsNullOrWhiteSpace(entity.ExternalEventId))
             {
                 var svc = _calSelector.For(entity.ExternalCalendar);
-                await svc.CancelEventAsync(entity.ExternalEventId, ct); // ✅ correct method
+                await svc.CancelEventAsync(entity.ExternalEventId, entity.ExternalCalendarMailbox, ct); // ✅ correct method
             }
 
             _db.Meetings.Remove(entity);

--- a/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
+++ b/src/BoardMgmt.Infrastructure/Calendars/Microsoft365CalendarService.cs
@@ -147,12 +147,16 @@ public sealed class Microsoft365CalendarService : ICalendarService
         return (true, joinUrl);
     }
 
-    public async Task CancelEventAsync(string eventId, CancellationToken ct = default)
+    public async Task CancelEventAsync(string eventId, string? mailbox = null, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(eventId)) return;
 
+        var resolvedMailbox = string.IsNullOrWhiteSpace(mailbox)
+            ? _opts.MailboxAddress
+            : mailbox!;
+
         await RunGraph(
-            () => _graph.Users[_opts.MailboxAddress].Events[eventId].DeleteAsync(cancellationToken: ct),
+            () => _graph.Users[resolvedMailbox].Events[eventId].DeleteAsync(cancellationToken: ct),
             "DELETE /users/{mailbox}/events/{id}", ct);
     }
 
@@ -562,7 +566,7 @@ public sealed class Microsoft365CalendarService : ICalendarService
                     {
                         var position = stream.Position;
                         using var seekableReader = new StreamReader(stream, leaveOpen: true);
-                         text = seekableReader.ReadToEnd();
+                        var text = seekableReader.ReadToEnd();
                         stream.Seek(position, SeekOrigin.Begin);
                         return text;
                     }

--- a/src/BoardMgmt.Infrastructure/Calendars/ZoomCalendarService.cs
+++ b/src/BoardMgmt.Infrastructure/Calendars/ZoomCalendarService.cs
@@ -140,9 +140,11 @@ public sealed class ZoomCalendarService : ICalendarService
     // ---------------------------
     // Delete
     // ---------------------------
-    public async Task CancelEventAsync(string eventId, CancellationToken ct = default)
+    public async Task CancelEventAsync(string eventId, string? mailbox = null, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(eventId)) return;
+
+        _ = mailbox; // Zoom API identifies meetings solely by the meeting id.
 
         var token = await GetAccessTokenAsync(ct);
         using var req = new HttpRequestMessage(


### PR DESCRIPTION
## Summary
- allow calendar services to accept an optional mailbox when cancelling external events
- ensure Microsoft 365 cancellations respect the stored mailbox and fix transcript logging helper stream handling
- adjust the Zoom implementation and meeting delete handler to use the new cancellation signature

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ece511c9f8832095a002647e16d352