### PR TITLE
Ensure Teams transcript requests include user id path parameter

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.Teams.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.Teams.cs
@@ -119,10 +119,16 @@ namespace BoardMgmt.Application.Meetings.Commands
             try
             {
                 return await ExecuteTranscriptRequestWithFallbackAsync(
-                    () => _graph.Users[mailbox]
-                        .OnlineMeetings[onlineMeetingId]
-                        .Transcripts
-                        .ToGetRequestInformation(),
+                    () =>
+                    {
+                        var request = _graph.Users[mailbox]
+                            .OnlineMeetings[onlineMeetingId]
+                            .Transcripts
+                            .ToGetRequestInformation();
+
+                        request.PathParameters["user%2Did"] = mailbox;
+                        return request;
+                    },
                     async requestInfo =>
                     {
                         var json = await _graph.RequestAdapter.SendPrimitiveAsync<string>(
@@ -278,11 +284,17 @@ namespace BoardMgmt.Application.Meetings.Commands
             try
             {
                 return await ExecuteTranscriptRequestWithFallbackAsync(
-                    () => _graph.Users[mailbox]
-                        .OnlineMeetings[onlineMeetingId]
-                        .Transcripts[transcriptId]
-                        .Content
-                        .ToGetRequestInformation(),
+                    () =>
+                    {
+                        var request = _graph.Users[mailbox]
+                            .OnlineMeetings[onlineMeetingId]
+                            .Transcripts[transcriptId]
+                            .Content
+                            .ToGetRequestInformation();
+
+                        request.PathParameters["user%2Did"] = mailbox;
+                        return request;
+                    },
                     requestInfo => _graph.RequestAdapter.SendPrimitiveAsync<Stream>(
                         requestInfo,
                         GraphErrorMapping,


### PR DESCRIPTION
## Summary
- ensure Teams transcript metadata and content requests explicitly set the user%2Did path parameter before sending
- avoid UnknownError responses when retrieving transcripts by keeping the user mailbox bound after overriding the base URL

## Testing
- ⚠️ `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf32ed59483208d0dfd2cf7ee550d