### PR TITLE
Set Teams transcript request path parameters

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.Teams.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.Teams.cs
@@ -119,10 +119,17 @@ namespace BoardMgmt.Application.Meetings.Commands
             try
             {
                 return await ExecuteTranscriptRequestWithFallbackAsync(
-                    () => _graph.Users[mailbox]
-                        .OnlineMeetings[onlineMeetingId]
-                        .Transcripts
-                        .ToGetRequestInformation(),
+                    () =>
+                    {
+                        var request = _graph.Users[mailbox]
+                            .OnlineMeetings[onlineMeetingId]
+                            .Transcripts
+                            .ToGetRequestInformation();
+
+                        request.PathParameters["user%2Did"] = mailbox;
+                        request.PathParameters["onlineMeeting%2Did"] = onlineMeetingId;
+                        return request;
+                    },
                     async requestInfo =>
                     {
                         var json = await _graph.RequestAdapter.SendPrimitiveAsync<string>(
@@ -278,11 +285,19 @@ namespace BoardMgmt.Application.Meetings.Commands
             try
             {
                 return await ExecuteTranscriptRequestWithFallbackAsync(
-                    () => _graph.Users[mailbox]
-                        .OnlineMeetings[onlineMeetingId]
-                        .Transcripts[transcriptId]
-                        .Content
-                        .ToGetRequestInformation(),
+                    () =>
+                    {
+                        var request = _graph.Users[mailbox]
+                            .OnlineMeetings[onlineMeetingId]
+                            .Transcripts[transcriptId]
+                            .Content
+                            .ToGetRequestInformation();
+
+                        request.PathParameters["user%2Did"] = mailbox;
+                        request.PathParameters["onlineMeeting%2Did"] = onlineMeetingId;
+                        request.PathParameters["teamsTranscript%2Did"] = transcriptId;
+                        return request;
+                    },
                     requestInfo => _graph.RequestAdapter.SendPrimitiveAsync<Stream>(
                         requestInfo,
                         GraphErrorMapping,


### PR DESCRIPTION
## Summary
- ensure Teams transcript metadata requests set both user and online meeting path parameters before sending
- set the user, online meeting, and transcript identifiers on transcript content requests so Microsoft Graph resolves the mailbox correctly

## Testing
- ⚠️ `dotnet --version` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf32ed59483208d0dfd2cf7ee550d