### PR TITLE
Default transcript ingestion to Microsoft 365

### DIFF
--- a/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
+++ b/src/BoardMgmt.Application/Meetings/Commands/IngestTranscriptHandler.cs
@@ -52,15 +52,13 @@ namespace BoardMgmt.Application.Meetings.Commands
                 .FirstOrDefaultAsync(m => m.Id == request.MeetingId, ct)
                 ?? throw new InvalidOperationException("Meeting not found.");
 
-            if (string.IsNullOrWhiteSpace(meeting.ExternalCalendar))
-                throw new InvalidOperationException("Meeting.ExternalCalendar not set.");
-
-            var provider = CalendarProviders.Normalize(meeting.ExternalCalendar);
+            var provider = CalendarProviders.Normalize(meeting.ExternalCalendar)
+                           ?? CalendarProviders.Microsoft365;
 
             if (!CalendarProviders.IsSupported(provider))
                 throw new InvalidOperationException($"Unsupported provider: {meeting.ExternalCalendar}");
 
-            if (meeting.ExternalCalendar != provider)
+            if (!string.Equals(meeting.ExternalCalendar, provider, StringComparison.Ordinal))
                 meeting.ExternalCalendar = provider;
 
             if (string.IsNullOrWhiteSpace(meeting.ExternalEventId))


### PR DESCRIPTION
## Summary
- default transcript ingestion to treat meetings without a provider as Microsoft 365
- persist the normalized provider value back on the meeting entity

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ee015cdee083209ee3d3502abe8023