### PR TITLE
Fix typing SignalR event for non-GUID user IDs

### DIFF
--- a/src/BoardMgmt.WebApi/Controllers/ChatController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/ChatController.cs
@@ -299,7 +299,7 @@ public class ChatController : ControllerBase
     [HttpPost("conversations/{id:guid}/typing")]
     public async Task<ActionResult> Typing(Guid id, [FromBody] bool isTyping)
     {
-        await ChatHubEvents.Typing(_hub, id, Guid.Parse(CurrentUserId), isTyping);
+        await ChatHubEvents.Typing(_hub, id, CurrentUserId, isTyping);
         return Ok();
     }
 

--- a/src/BoardMgmt.WebApi/Hubs/ChatHubEvents.cs
+++ b/src/BoardMgmt.WebApi/Hubs/ChatHubEvents.cs
@@ -21,7 +21,7 @@ namespace BoardMgmt.WebApi.Hubs
             => hub.Clients.Group($"conv:{conversationId}")
                 .SendAsync("ReactionUpdated", payload);
 
-        public static Task Typing(IHubContext<ChatHub> hub, Guid conversationId, Guid userId, bool isTyping)
+        public static Task Typing(IHubContext<ChatHub> hub, Guid conversationId, string userId, bool isTyping)
             => hub.Clients.Group($"conv:{conversationId}")
                 .SendAsync("Typing", new { conversationId, userId, isTyping, at = DateTime.UtcNow });
     }


### PR DESCRIPTION
## Summary
- allow the ChatHub typing notification to accept string user identifiers
- avoid parsing the current user ID to a GUID before broadcasting typing events

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f15e13d16c83209a36b1c1617278b5