### PR TITLE
Improve real-time chat message updates

### DIFF
--- a/src/BoardMgmt.WebApi/Hubs/ChatHubEvents.cs
+++ b/src/BoardMgmt.WebApi/Hubs/ChatHubEvents.cs
@@ -1,20 +1,23 @@
 ﻿// Hubs/ChatHubEvents.cs
+using BoardMgmt.Application.Chat;
 using Microsoft.AspNetCore.SignalR;
 
 namespace BoardMgmt.WebApi.Hubs
 {
     public static class ChatHubEvents
     {
-        public static Task MessageCreated(IHubContext<ChatHub> hub, Guid conversationId, object payload)
-            => hub.Clients.Group($"conv:{conversationId}")
+        public record MessageChangePayload(Guid ConversationId, Guid? ThreadRootId, ChatMessageDto Message, ChatMessageDto? ThreadRoot);
+
+        public static Task MessageCreated(IHubContext<ChatHub> hub, MessageChangePayload payload)
+            => hub.Clients.Group($"conv:{payload.ConversationId}")
                 .SendAsync("MessageCreated", payload);
 
-        public static Task MessageEdited(IHubContext<ChatHub> hub, Guid conversationId, object payload)
-            => hub.Clients.Group($"conv:{conversationId}")
+        public static Task MessageEdited(IHubContext<ChatHub> hub, MessageChangePayload payload)
+            => hub.Clients.Group($"conv:{payload.ConversationId}")
                 .SendAsync("MessageEdited", payload);
 
-        public static Task MessageDeleted(IHubContext<ChatHub> hub, Guid conversationId, object payload)
-            => hub.Clients.Group($"conv:{conversationId}")
+        public static Task MessageDeleted(IHubContext<ChatHub> hub, MessageChangePayload payload)
+            => hub.Clients.Group($"conv:{payload.ConversationId}")
                 .SendAsync("MessageDeleted", payload);
 
         public static Task ReactionUpdated(IHubContext<ChatHub> hub, Guid conversationId, object payload)

--- a/src/boardmgmt-frontend/src/app/features/chat/chat.models.ts
+++ b/src/boardmgmt-frontend/src/app/features/chat/chat.models.ts
@@ -56,21 +56,16 @@ export interface PagedResult<T> {
 }
 
 /** SignalR event payloads we expect from the server */
-export interface MessageCreatedEvent {
-  id: string;
+export interface MessageChangedEvent {
   conversationId: string;
   threadRootId?: string | null;
+  message: ChatMessageDto;
+  threadRoot?: ChatMessageDto | null;
 }
-export interface MessageEditedEvent {
-  id: string;
-  conversationId: string;
-  threadRootId?: string | null;
-}
-export interface MessageDeletedEvent {
-  id: string;
-  conversationId: string;
-  threadRootId?: string | null;
-}
+
+export type MessageCreatedEvent = MessageChangedEvent;
+export type MessageEditedEvent = MessageChangedEvent;
+export type MessageDeletedEvent = MessageChangedEvent;
 export interface ReactionUpdatedEvent {
   messageId: string;
   conversationId: string;


### PR DESCRIPTION
## Summary
- broadcast full chat message details (and updated thread roots) whenever messages are created, edited, or deleted
- add a typed hub payload for message change events so SignalR clients receive structured data
- update the Angular chat UI to consume the richer payloads and update conversations/threads in place without full refreshes

## Testing
- `dotnet test` *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f1e639637c83209fcdbaf114c65905