### PR TITLE
Align authorization policies with module permissions

### DIFF
--- a/src/BoardMgmt.WebApi/Controllers/AuthController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/AuthController.cs
@@ -95,7 +95,7 @@ public class AuthController(ISender mediator) : ControllerBase
 
     // PUT /api/auth/{id}/roles
     [HttpPut("{id}/roles")]
-    [Authorize] // or [Authorize(Policy = "Users.ManageRoles")]
+    [Authorize(Policy = "Users.Update")] // require ability to manage user assignments
     public async Task<IActionResult> AssignRoles(string id, [FromBody] AssignRolesBody body, CancellationToken ct)
     {
         var result = await mediator.Send(new AssignRoleCommand(id, body.Roles), ct);

--- a/src/BoardMgmt.WebApi/Controllers/CalendarController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/CalendarController.cs
@@ -23,7 +23,7 @@ public sealed class CalendarController : ControllerBase
 
     // GET /api/calendar/range?start=2025-09-01T00:00:00Z&end=2025-09-30T23:59:59Z&provider=Zoom|Microsoft365|All
     [HttpGet("range")]
-    [Authorize]
+    [Authorize(Policy = "Meetings.View")]
     public async Task<ActionResult<IReadOnlyList<CalendarEventDto>>> GetRange(
         [FromQuery] DateTimeOffset? start,
         [FromQuery] DateTimeOffset? end,
@@ -73,7 +73,7 @@ public sealed class CalendarController : ControllerBase
     }
 
     [HttpGet("range-db")]
-    [Authorize]
+    [Authorize(Policy = "Meetings.View")]
     public async Task<IReadOnlyList<CalendarEventDto>> GetRangeFromDb(
         [FromQuery] DateTimeOffset? start,
         [FromQuery] DateTimeOffset? end,
@@ -91,7 +91,7 @@ public sealed class CalendarController : ControllerBase
 
 
     [HttpPut("move/{id:guid}")]
-    [Authorize]
+    [Authorize(Policy = "Meetings.Update")]
     public async Task<IActionResult> Move(Guid id, [FromBody] MoveCalendarEventDto body, CancellationToken ct)
     {
         if (body is null) return BadRequest("Body required.");

--- a/src/BoardMgmt.WebApi/Controllers/ChatController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/ChatController.cs
@@ -15,7 +15,7 @@ namespace BoardMgmt.WebApi.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[Authorize]
+[Authorize(Policy = "Messages.View")]
 public class ChatController : ControllerBase
 {
     private readonly ISender _mediator;

--- a/src/BoardMgmt.WebApi/Controllers/DocumentsController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/DocumentsController.cs
@@ -14,7 +14,7 @@ namespace BoardMgmt.WebApi.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[Authorize]
+[Authorize(Policy = "Documents.View")]
 public class DocumentsController : ControllerBase
 {
     private readonly IMediator _mediator;

--- a/src/BoardMgmt.WebApi/Controllers/FoldersController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/FoldersController.cs
@@ -10,7 +10,7 @@ namespace BoardMgmt.WebApi.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[Authorize] // class-level; GET is explicitly AllowAnonymous below
+[Authorize(Policy = "Folders.View")] // class-level; GET is explicitly AllowAnonymous below
 public class FoldersController : ControllerBase
 {
     private readonly IMediator _mediator;
@@ -29,7 +29,7 @@ public class FoldersController : ControllerBase
     // -------------------- CREATE --------------------
 
     [HttpPost]
-    [Authorize(Policy = "Meetings.Create")]
+    [Authorize(Policy = "Folders.Create")]
     public async Task<IActionResult> Create([FromBody] CreateFolderCommand cmd, CancellationToken ct)
     {
         try

--- a/src/BoardMgmt.WebApi/Controllers/MeetingsController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/MeetingsController.cs
@@ -20,7 +20,7 @@ public class MeetingsController : ControllerBase
     // GET /api/meetings
     // -----------------------------
     [HttpGet]
-    [Authorize]
+    [Authorize(Policy = "Meetings.View")]
     public async Task<IActionResult> GetAll(CancellationToken ct)
         => this.OkApi(await _mediator.Send(new GetMeetingsQuery(), ct));
 
@@ -28,7 +28,7 @@ public class MeetingsController : ControllerBase
     // GET /api/meetings/{id}
     // -----------------------------
     [HttpGet("{id:guid}")]
-    [Authorize]
+    [Authorize(Policy = "Meetings.View")]
     public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
     {
         var dto = await _mediator.Send(new GetMeetingByIdQuery(id), ct);
@@ -146,7 +146,7 @@ public class MeetingsController : ControllerBase
     // returns latest transcript by CreatedUtc
     // -----------------------------
     [HttpGet("{id:guid}/transcripts")]
-    [Authorize]
+    [Authorize(Policy = "Meetings.View")]
     public async Task<IActionResult> GetTranscript(Guid id, CancellationToken ct)
     {
         var tr = await _mediator.Send(new GetTranscriptByMeetingIdQuery(id), ct);

--- a/src/BoardMgmt.WebApi/Controllers/ReportsController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/ReportsController.cs
@@ -17,19 +17,19 @@ public class ReportsController : ControllerBase
 
     // GET: /api/reports/dashboard?months=6
     [HttpGet("dashboard")]
-    [Authorize]
+    [Authorize(Policy = "Reports.View")]
     public async Task<IActionResult> Dashboard([FromQuery] int months = 6)
         => this.OkApi(await _mediator.Send(new GetReportsDashboardQuery(months)));
 
     // GET: /api/reports/recent?take=10
     [HttpGet("recent")]
-    [Authorize]
+    [Authorize(Policy = "Reports.View")]
     public async Task<IActionResult> Recent([FromQuery] int take = 10)
         => this.OkApi(await _mediator.Send(new GetRecentReportsQuery(take)));
 
     // POST: /api/reports/generate
     [HttpPost("generate")]
-    [Authorize]
+    [Authorize(Policy = "Reports.Create")]
     public async Task<IActionResult> Generate([FromBody] GenerateReportCommand command)
     {
         var id = await _mediator.Send(command);

--- a/src/BoardMgmt.WebApi/Controllers/RolesController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/RolesController.cs
@@ -16,7 +16,7 @@ namespace BoardMgmt.WebApi.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    [Authorize]
+    [Authorize(Policy = "Users.View")]
     public class RolesController(ISender mediator, IRoleService roles) : ControllerBase
     {
         [HttpGet]

--- a/src/BoardMgmt.WebApi/Controllers/VotesController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/VotesController.cs
@@ -56,7 +56,7 @@ public class VotesController : ControllerBase
         => Ok(await _mediator.Send(new GetActiveVotesQuery()));
 
     [HttpGet("recent")]
-    [Authorize]
+    [Authorize(Policy = "Votes.View")]
     public async Task<ActionResult<IReadOnlyList<VoteSummaryDto>>> Recent()
         => Ok(await _mediator.Send(new GetRecentVotesQuery()));
 
@@ -98,7 +98,7 @@ public class VotesController : ControllerBase
 
     // BoardMgmt.WebApi/Controllers/VotesController.cs
     [HttpPost("{id:guid}/ballots")]
-    [Authorize]
+    [Authorize(Policy = "Votes.View")]
     public async Task<ActionResult<VoteSummaryDto>> Submit(Guid id, [FromBody] SubmitDto body)
     {
         var summary = await _mediator.Send(new SubmitBallotCommand(id, body.Choice, body.OptionId));

--- a/src/BoardMgmt.WebApi/Hubs/ChatHub.cs
+++ b/src/BoardMgmt.WebApi/Hubs/ChatHub.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace BoardMgmt.WebApi.Hubs;
 
-[Authorize]
+[Authorize(Policy = "Messages.View")]
 public class ChatHub : Hub
 {
     public Task JoinUser(string userId)


### PR DESCRIPTION
## Summary
- require module-specific authorization policies on meetings, documents, folders, chat, votes, and reports endpoints
- align role and user management endpoints with Users permissions and secure the SignalR chat hub

## Testing
- `dotnet build` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f20ba0be448320b77b9ea0b84212f4