### PR TITLE
Fix typing for forbidden fallbacks in users service

### DIFF
--- a/src/boardmgmt-frontend/src/app/features/users/users.service.ts
+++ b/src/boardmgmt-frontend/src/app/features/users/users.service.ts
@@ -99,7 +99,10 @@ export class UsersService {
       .get<any>(`${this.base}auth`, { params, context })
       .pipe(
         map((body) => this.unwrapPaged<UserDto>(body)),
-        this.onForbiddenReturn(() => ({ items: [], total: 0 }), opts.suppressForbidden ?? false),
+        this.onForbiddenReturn<PagedResult<UserDto>>(
+          () => ({ items: [] as UserDto[], total: 0 }),
+          opts.suppressForbidden ?? false,
+        ),
       );
   }
 
@@ -113,7 +116,7 @@ export class UsersService {
       .get<any>(`${this.base}auth`, { context })
       .pipe(
         map((body) => this.unwrapArray<UserDto>(body)),
-        this.onForbiddenReturn(() => [], opts.suppressForbidden ?? false),
+        this.onForbiddenReturn<UserDto[]>(() => [] as UserDto[], opts.suppressForbidden ?? false),
       );
   }
 
@@ -130,7 +133,7 @@ export class UsersService {
         map((list: RoleDto[]) =>
           list.map((r: RoleDto): RoleOption => ({ id: r.id, name: r.name })),
         ),
-        this.onForbiddenReturn(() => [], opts.suppressForbidden ?? false),
+        this.onForbiddenReturn<RoleOption[]>(() => [] as RoleOption[], opts.suppressForbidden ?? false),
       );
   }
 
@@ -153,7 +156,10 @@ export class UsersService {
       })
       .pipe(
         map((body) => this.unwrapArray<DepartmentDto>(body)),
-        this.onForbiddenReturn(() => [], opts.suppressForbidden ?? false),
+        this.onForbiddenReturn<DepartmentDto[]>(
+          () => [] as DepartmentDto[],
+          opts.suppressForbidden ?? false,
+        ),
       );
   }
 


### PR DESCRIPTION
## Summary
- ensure the forbidden fallback helper is invoked with explicit generics for each users service method
- return typed empty collections so RxJS pipes keep their expected observable shapes

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f24315578083208f327211b529dfea