### PR TITLE
Adjust role controller policy for page-only users

### DIFF
--- a/src/BoardMgmt.WebApi/Controllers/RolesController.cs
+++ b/src/BoardMgmt.WebApi/Controllers/RolesController.cs
@@ -17,7 +17,7 @@ namespace BoardMgmt.WebApi.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    [Authorize(Policy = PolicyNames.Users.View)]
+    [Authorize]
     public class RolesController(ISender mediator, IRoleService roles) : ControllerBase
     {
         [HttpGet]


### PR DESCRIPTION
## Summary
- require only authentication on RolesController and keep action-level policies so users with page permissions can load dropdown data

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f2458bd6e08320a1b0854d2b48d18f