### PR TITLE
feat(frontend): redesign shell navigation layout

### DIFF
--- a/src/boardmgmt-frontend/src/app/layout/shell/shell.component.html
+++ b/src/boardmgmt-frontend/src/app/layout/shell/shell.component.html
@@ -1,86 +1,152 @@
-<div class="container-fluid">
-  <div class="row">
-    <!-- Sidebar -->
-    <nav class="col-md-3 col-lg-2 d-md-block sidebar collapse">
-      <div class="position-sticky pt-3">
-        <div class="text-center mb-4">
-          <i class="fas fa-users-cog fa-2x text-white mb-2"></i>
-          <h5 class="text-white">Board Portal</h5>
-        </div>
+<div class="shell">
+  <div class="shell__backdrop" *ngIf="sidebarOpen" (click)="toggleSidebar()"></div>
 
-        <ul class="nav flex-column">
-          <li class="nav-item" *ngIf="can(AppModule.Dashboard)">
-            <a class="nav-link" routerLink="/dashboard" routerLinkActive="active">
-              <i class="fas fa-tachometer-alt"></i> Dashboard
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Meetings)">
-            <a class="nav-link" routerLink="/meetings" routerLinkActive="active">
-              <i class="fas fa-calendar-alt"></i> Meetings
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Documents)">
-            <a class="nav-link" routerLink="/documents" routerLinkActive="active">
-              <i class="fas fa-file-alt"></i> Documents
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Votes)">
-            <a class="nav-link" routerLink="/voting" routerLinkActive="active">
-              <i class="fas fa-vote-yea"></i> Voting
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Reports)">
-            <a class="nav-link" routerLink="/reports" routerLinkActive="active">
-              <i class="fas fa-chart-bar"></i> Reports
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Messages)">
-            <a class="nav-link" routerLink="/messages" routerLinkActive="active">
-              <i class="fas fa-comments"></i> Messages
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Users)">
-            <a class="nav-link" routerLink="/users" routerLinkActive="active">
-              <i class="fas fa-users"></i> Users
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Settings)">
-            <!-- if your Roles UI lives at /settings/roles, keep this link -->
-            <a class="nav-link" routerLink="/settings/roles" routerLinkActive="active">
-              <i class="fas fa-cog"></i> Settings
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Settings)">
-            <!-- if your Roles UI lives at /settings/roles, keep this link -->
-            <a class="nav-link" routerLink="/roles" routerLinkActive="active">
-              <i class="fas fa-user-shield"></i> Role
-            </a>
-          </li>
-        </ul>
-
-        <hr class="my-3" style="border-color: rgba(255, 255, 255, 0.2)" />
-
-        <ul class="nav flex-column">
-          <li class="nav-item">
-            <a class="nav-link" href="/auth" (click)="onLogout($event)">
-              <i class="fas fa-sign-out-alt"></i> Logout
-            </a>
-          </li>
-        </ul>
+  <aside class="shell__sidebar" [class.open]="sidebarOpen">
+    <div class="sidebar__brand">
+      <div class="sidebar__brand-icon">
+        <i class="fas fa-chess-king"></i>
       </div>
+      <div>
+        <h1>Board Portal</h1>
+        <p>Governance Suite</p>
+      </div>
+    </div>
+
+    <nav class="sidebar__nav">
+      <p class="sidebar__section">Workspace</p>
+      <a
+        class="sidebar__link"
+        routerLink="/dashboard"
+        routerLinkActive="active"
+        *ngIf="can(AppModule.Dashboard)"
+        (click)="closeSidebar()"
+      >
+        <i class="fas fa-tachometer-alt"></i>
+        <span>Dashboard</span>
+      </a>
+      <a
+        class="sidebar__link"
+        routerLink="/meetings"
+        routerLinkActive="active"
+        *ngIf="can(AppModule.Meetings)"
+        (click)="closeSidebar()"
+      >
+        <i class="fas fa-calendar-alt"></i>
+        <span>Meetings</span>
+      </a>
+      <a
+        class="sidebar__link"
+        routerLink="/documents"
+        routerLinkActive="active"
+        *ngIf="can(AppModule.Documents)"
+        (click)="closeSidebar()"
+      >
+        <i class="fas fa-file-alt"></i>
+        <span>Documents</span>
+      </a>
+      <a
+        class="sidebar__link"
+        routerLink="/voting"
+        routerLinkActive="active"
+        *ngIf="can(AppModule.Votes)"
+        (click)="closeSidebar()"
+      >
+        <i class="fas fa-vote-yea"></i>
+        <span>Voting</span>
+      </a>
+      <a
+        class="sidebar__link"
+        routerLink="/reports"
+        routerLinkActive="active"
+        *ngIf="can(AppModule.Reports)"
+        (click)="closeSidebar()"
+      >
+        <i class="fas fa-chart-bar"></i>
+        <span>Reports</span>
+      </a>
+      <a
+        class="sidebar__link"
+        routerLink="/messages"
+        routerLinkActive="active"
+        *ngIf="can(AppModule.Messages)"
+        (click)="closeSidebar()"
+      >
+        <i class="fas fa-comments"></i>
+        <span>Messages</span>
+      </a>
+
+      <p class="sidebar__section" *ngIf="can(AppModule.Users) || can(AppModule.Settings)">
+        Administration
+      </p>
+      <a
+        class="sidebar__link"
+        routerLink="/users"
+        routerLinkActive="active"
+        *ngIf="can(AppModule.Users)"
+        (click)="closeSidebar()"
+      >
+        <i class="fas fa-users"></i>
+        <span>Users</span>
+      </a>
+      <a
+        class="sidebar__link"
+        routerLink="/settings/roles"
+        routerLinkActive="active"
+        *ngIf="can(AppModule.Settings)"
+        (click)="closeSidebar()"
+      >
+        <i class="fas fa-cog"></i>
+        <span>Settings</span>
+      </a>
+      <a
+        class="sidebar__link"
+        routerLink="/roles"
+        routerLinkActive="active"
+        *ngIf="can(AppModule.Settings)"
+        (click)="closeSidebar()"
+      >
+        <i class="fas fa-user-shield"></i>
+        <span>Roles</span>
+      </a>
     </nav>
 
-    <!-- Main content -->
-    <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4 main-content">
-      <router-outlet></router-outlet>
+    <div class="sidebar__footer">
+      <button type="button" class="sidebar__logout" (click)="onLogout($event)">
+        <i class="fas fa-sign-out-alt"></i>
+        <span>Logout</span>
+      </button>
+    </div>
+  </aside>
+
+  <div class="shell__workspace">
+    <header class="workspace__topbar">
+      <button class="topbar__menu" type="button" (click)="toggleSidebar()" aria-label="Toggle navigation">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+
+      <div class="topbar__title">
+        <h2>Boardroom Overview</h2>
+        <p>Stay ahead of meetings, votes, and compliance tasks.</p>
+      </div>
+
+      <div class="topbar__actions">
+        <label class="topbar__search">
+          <i class="fas fa-search"></i>
+          <input type="search" placeholder="Search boards, tasks, documents" />
+        </label>
+        <a class="topbar__action" routerLink="/meetings" (click)="closeSidebar()">
+          <i class="fas fa-plus"></i>
+          Schedule Meeting
+        </a>
+      </div>
+    </header>
+
+    <main class="workspace__content">
+      <div class="workspace__surface">
+        <router-outlet></router-outlet>
+      </div>
     </main>
   </div>
 </div>

--- a/src/boardmgmt-frontend/src/app/layout/shell/shell.component.scss
+++ b/src/boardmgmt-frontend/src/app/layout/shell/shell.component.scss
@@ -1,0 +1,384 @@
+:host {
+  display: block;
+  min-height: 100vh;
+  background: linear-gradient(160deg, #f5f7fb 0%, #eef2f9 45%, #f8f0ff 100%);
+}
+
+.shell {
+  position: relative;
+  display: flex;
+  min-height: 100vh;
+  color: #1b1d29;
+  overflow: hidden;
+}
+
+.shell__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(16, 18, 32, 0.4);
+  backdrop-filter: blur(6px);
+  z-index: 40;
+}
+
+.shell__sidebar {
+  width: 280px;
+  background: linear-gradient(180deg, #1b2a4a 0%, #233b6c 45%, #2f3d87 100%);
+  color: #f6f7fb;
+  display: flex;
+  flex-direction: column;
+  padding: 2.5rem 2rem 1.5rem;
+  gap: 2rem;
+  position: relative;
+  z-index: 50;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 12px 0 32px rgba(18, 20, 45, 0.2);
+}
+
+.shell__sidebar::before {
+  content: '';
+  position: absolute;
+  inset: 20% -60% -30% 40%;
+  background: radial-gradient(ellipse at center, rgba(255, 255, 255, 0.1), transparent 70%);
+  pointer-events: none;
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.sidebar__brand-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0.05));
+  color: #ffffff;
+  font-size: 1.6rem;
+  box-shadow: 0 16px 24px rgba(9, 13, 32, 0.35);
+}
+
+.sidebar__brand h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin: 0;
+}
+
+.sidebar__brand p {
+  margin: 0;
+  opacity: 0.7;
+  font-size: 0.875rem;
+}
+
+.sidebar__nav {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.sidebar__section {
+  margin: 1.5rem 0 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.68rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.sidebar__link {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.85rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: none;
+  transition: all 0.25s ease;
+  position: relative;
+}
+
+.sidebar__link::after {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: inherit;
+  background: rgba(255, 255, 255, 0.06);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.sidebar__link i {
+  width: 20px;
+  text-align: center;
+  font-size: 1rem;
+}
+
+.sidebar__link:hover,
+.sidebar__link.active {
+  color: #ffffff;
+  transform: translateX(6px);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.sidebar__link:hover::after,
+.sidebar__link.active::after {
+  opacity: 1;
+}
+
+.sidebar__footer {
+  margin-top: auto;
+}
+
+.sidebar__logout {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.85rem;
+  border-radius: 1rem;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.sidebar__logout:hover {
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateY(-1px);
+}
+
+.shell__workspace {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  z-index: 10;
+}
+
+.workspace__topbar {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.75rem 2.5rem 1.5rem;
+  position: relative;
+}
+
+.workspace__topbar::after {
+  content: '';
+  position: absolute;
+  inset: 0 0 -1.5rem 0;
+  background: rgba(255, 255, 255, 0.65);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(41, 53, 99, 0.08);
+  z-index: -1;
+}
+
+.topbar__menu {
+  display: none;
+  flex-direction: column;
+  gap: 0.3rem;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.topbar__menu span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: #1b1d29;
+  border-radius: 999px;
+}
+
+.topbar__title h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.topbar__title p {
+  margin: 0.2rem 0 0;
+  color: rgba(27, 29, 41, 0.65);
+  font-size: 0.95rem;
+}
+
+.topbar__actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.topbar__search {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(63, 80, 130, 0.12);
+  box-shadow: 0 12px 24px rgba(15, 27, 68, 0.08);
+}
+
+.topbar__search i {
+  color: rgba(27, 29, 41, 0.45);
+  font-size: 0.9rem;
+}
+
+.topbar__search input {
+  border: none;
+  outline: none;
+  font-size: 0.95rem;
+  min-width: 220px;
+  background: transparent;
+  color: inherit;
+}
+
+.topbar__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 1.2rem;
+  border-radius: 0.9rem;
+  text-decoration: none;
+  font-weight: 600;
+  color: #ffffff;
+  background: linear-gradient(140deg, #5561ff 0%, #8060ff 50%, #ff6ec7 100%);
+  box-shadow: 0 14px 24px rgba(72, 85, 255, 0.25);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.topbar__action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px rgba(72, 85, 255, 0.3);
+}
+
+.workspace__content {
+  flex: 1;
+  padding: 2.5rem 2.5rem 3rem;
+  position: relative;
+}
+
+.workspace__content::before,
+.workspace__content::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(0px);
+  z-index: -1;
+}
+
+.workspace__content::before {
+  top: 20%;
+  right: -160px;
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(circle, rgba(128, 96, 255, 0.16), transparent 70%);
+}
+
+.workspace__content::after {
+  bottom: 10%;
+  left: -140px;
+  width: 260px;
+  height: 260px;
+  background: radial-gradient(circle, rgba(255, 110, 199, 0.18), transparent 70%);
+}
+
+.workspace__surface {
+  min-height: calc(100vh - 200px);
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 1.75rem;
+  border: 1px solid rgba(63, 80, 130, 0.08);
+  box-shadow: 0 28px 60px rgba(31, 38, 89, 0.12);
+  padding: 2rem;
+  backdrop-filter: blur(14px);
+}
+
+@media (max-width: 1200px) {
+  .topbar__search input {
+    min-width: 160px;
+  }
+}
+
+@media (max-width: 992px) {
+  .shell__sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    transform: translateX(-100%);
+    box-shadow: 0 20px 60px rgba(18, 20, 45, 0.4);
+  }
+
+  .shell__sidebar.open {
+    transform: translateX(0);
+  }
+
+  .topbar__menu {
+    display: flex;
+  }
+
+  .topbar__title h2 {
+    font-size: 1.35rem;
+  }
+
+  .topbar__actions {
+    gap: 0.6rem;
+  }
+
+  .topbar__action {
+    padding: 0.6rem 1rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .workspace__topbar {
+    flex-wrap: wrap;
+    padding: 1.4rem 1.6rem 1.2rem;
+  }
+
+  .topbar__actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .topbar__search {
+    flex: 1;
+  }
+
+  .topbar__search input {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .topbar__action {
+    white-space: nowrap;
+  }
+
+  .workspace__content {
+    padding: 1.5rem 1.4rem 2.4rem;
+  }
+
+  .workspace__surface {
+    padding: 1.5rem;
+    border-radius: 1.2rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .topbar__actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.8rem;
+  }
+
+  .topbar__action {
+    justify-content: center;
+  }
+}

--- a/src/boardmgmt-frontend/src/app/layout/shell/shell.component.ts
+++ b/src/boardmgmt-frontend/src/app/layout/shell/shell.component.ts
@@ -25,6 +25,9 @@ export class ShellComponent implements OnInit {
   private storage = inject(BROWSER_STORAGE);
   private router = inject(Router);
 
+  /** Mobile sidebar toggle */
+  sidebarOpen = false;
+
   ngOnInit(): void {
     // load once; MeService is idempotent
     this.me.loadPermissions();
@@ -39,5 +42,16 @@ export class ShellComponent implements OnInit {
     e.preventDefault();
     this.storage.removeItem('jwt');
     this.router.navigateByUrl('/auth');
+    this.sidebarOpen = false;
+  }
+
+  toggleSidebar() {
+    this.sidebarOpen = !this.sidebarOpen;
+  }
+
+  closeSidebar() {
+    if (this.sidebarOpen) {
+      this.sidebarOpen = false;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- replace the legacy bootstrap-based shell with a modern sidebar and workspace layout
- add responsive sidebar toggling, top bar actions, and search affordance for navigation
- refresh shell styling with gradients, glassmorphism surface, and refined typography

## Testing
- not run (npm install hung in container)

------
https://chatgpt.com/codex/tasks/task_e_68f26ea509c88320907e107cfd2bb59a