### PR TITLE
Revamp application shell layout

### DIFF
--- a/src/boardmgmt-frontend/src/app/layout/shell/shell.component.html
+++ b/src/boardmgmt-frontend/src/app/layout/shell/shell.component.html
@@ -1,86 +1,181 @@
-<div class="container-fluid">
-  <div class="row">
-    <!-- Sidebar -->
-    <nav class="col-md-3 col-lg-2 d-md-block sidebar collapse">
-      <div class="position-sticky pt-3">
-        <div class="text-center mb-4">
-          <i class="fas fa-users-cog fa-2x text-white mb-2"></i>
-          <h5 class="text-white">Board Portal</h5>
+<div class="app-shell">
+  <aside class="sidebar">
+    <div class="sidebar__brand">
+      <div class="sidebar__brand-icon">
+        <i class="fas fa-users-cog"></i>
+      </div>
+      <div>
+        <div class="sidebar__title">Board Portal</div>
+        <div class="sidebar__subtitle">Governance Suite</div>
+      </div>
+    </div>
+
+    <div class="sidebar__menu">
+      <div class="sidebar__section">
+        <p class="sidebar__label">Workspace</p>
+        <a
+          *ngIf="can(AppModule.Dashboard)"
+          class="sidebar__link"
+          routerLink="/dashboard"
+          routerLinkActive="is-active"
+          [routerLinkActiveOptions]="{ exact: true }"
+        >
+          <i class="fas fa-tachometer-alt"></i>
+          <span>Dashboard</span>
+        </a>
+
+        <a
+          *ngIf="can(AppModule.Meetings)"
+          class="sidebar__link"
+          routerLink="/meetings"
+          routerLinkActive="is-active"
+        >
+          <i class="fas fa-calendar-alt"></i>
+          <span>Meetings</span>
+        </a>
+
+        <a
+          *ngIf="can(AppModule.Documents)"
+          class="sidebar__link"
+          routerLink="/documents"
+          routerLinkActive="is-active"
+        >
+          <i class="fas fa-file-alt"></i>
+          <span>Documents</span>
+        </a>
+
+        <a
+          *ngIf="can(AppModule.Votes)"
+          class="sidebar__link"
+          routerLink="/voting"
+          routerLinkActive="is-active"
+        >
+          <i class="fas fa-vote-yea"></i>
+          <span>Voting</span>
+        </a>
+
+        <a
+          *ngIf="can(AppModule.Reports)"
+          class="sidebar__link"
+          routerLink="/reports"
+          routerLinkActive="is-active"
+        >
+          <i class="fas fa-chart-bar"></i>
+          <span>Reports</span>
+        </a>
+
+        <a
+          *ngIf="can(AppModule.Messages)"
+          class="sidebar__link"
+          routerLink="/messages"
+          routerLinkActive="is-active"
+        >
+          <i class="fas fa-comments"></i>
+          <span>Messages</span>
+        </a>
+      </div>
+
+      <div class="sidebar__section">
+        <p class="sidebar__label">Administration</p>
+
+        <a
+          *ngIf="can(AppModule.Users)"
+          class="sidebar__link"
+          routerLink="/users"
+          routerLinkActive="is-active"
+        >
+          <i class="fas fa-users"></i>
+          <span>Users</span>
+        </a>
+
+        <a
+          *ngIf="can(AppModule.Settings)"
+          class="sidebar__link"
+          routerLink="/settings/roles"
+          routerLinkActive="is-active"
+        >
+          <i class="fas fa-cog"></i>
+          <span>Settings</span>
+        </a>
+
+        <a
+          *ngIf="can(AppModule.Settings)"
+          class="sidebar__link"
+          routerLink="/roles"
+          routerLinkActive="is-active"
+        >
+          <i class="fas fa-user-shield"></i>
+          <span>Roles</span>
+        </a>
+      </div>
+    </div>
+
+    <div class="sidebar__footer">
+      <div class="sidebar__status">
+        <i class="fas fa-shield-alt"></i>
+        <div>
+          <span class="sidebar__status-title">Secure workspace</span>
+          <small class="sidebar__status-subtitle">Sessions encrypted</small>
+        </div>
+      </div>
+      <button type="button" class="sidebar__logout" (click)="onLogout()">
+        <i class="fas fa-sign-out-alt"></i>
+        <span>Logout</span>
+      </button>
+    </div>
+  </aside>
+
+  <div class="app-shell__main">
+    <header class="topbar">
+      <div class="topbar__greeting">
+        <span class="topbar__eyebrow">Board Management Platform</span>
+        <h1>Unified command center</h1>
+        <p>Monitor meetings, collaborate on documents, and track board activity.</p>
+      </div>
+
+      <div class="topbar__actions">
+        <div class="topbar__search" role="search">
+          <i class="fas fa-search"></i>
+          <input type="search" placeholder="Search meetings, documents, or members" aria-label="Search workspace" />
         </div>
 
-        <ul class="nav flex-column">
-          <li class="nav-item" *ngIf="can(AppModule.Dashboard)">
-            <a class="nav-link" routerLink="/dashboard" routerLinkActive="active">
-              <i class="fas fa-tachometer-alt"></i> Dashboard
-            </a>
-          </li>
+        <div class="topbar__quick-links">
+          <a
+            *ngIf="can(AppModule.Meetings)"
+            class="pill-link"
+            routerLink="/meetings"
+          >
+            <i class="fas fa-calendar-plus"></i>
+            <span>New meeting</span>
+          </a>
 
-          <li class="nav-item" *ngIf="can(AppModule.Meetings)">
-            <a class="nav-link" routerLink="/meetings" routerLinkActive="active">
-              <i class="fas fa-calendar-alt"></i> Meetings
-            </a>
-          </li>
+          <a
+            *ngIf="can(AppModule.Documents)"
+            class="pill-link pill-link--outline"
+            routerLink="/documents"
+          >
+            <i class="fas fa-file-upload"></i>
+            <span>Upload files</span>
+          </a>
 
-          <li class="nav-item" *ngIf="can(AppModule.Documents)">
-            <a class="nav-link" routerLink="/documents" routerLinkActive="active">
-              <i class="fas fa-file-alt"></i> Documents
-            </a>
-          </li>
+          <a
+            *ngIf="can(AppModule.Messages)"
+            class="pill-link pill-link--outline"
+            routerLink="/messages"
+          >
+            <i class="fas fa-paper-plane"></i>
+            <span>Send message</span>
+          </a>
+        </div>
 
-          <li class="nav-item" *ngIf="can(AppModule.Votes)">
-            <a class="nav-link" routerLink="/voting" routerLinkActive="active">
-              <i class="fas fa-vote-yea"></i> Voting
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Reports)">
-            <a class="nav-link" routerLink="/reports" routerLinkActive="active">
-              <i class="fas fa-chart-bar"></i> Reports
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Messages)">
-            <a class="nav-link" routerLink="/messages" routerLinkActive="active">
-              <i class="fas fa-comments"></i> Messages
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Users)">
-            <a class="nav-link" routerLink="/users" routerLinkActive="active">
-              <i class="fas fa-users"></i> Users
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Settings)">
-            <!-- if your Roles UI lives at /settings/roles, keep this link -->
-            <a class="nav-link" routerLink="/settings/roles" routerLinkActive="active">
-              <i class="fas fa-cog"></i> Settings
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Settings)">
-            <!-- if your Roles UI lives at /settings/roles, keep this link -->
-            <a class="nav-link" routerLink="/roles" routerLinkActive="active">
-              <i class="fas fa-user-shield"></i> Role
-            </a>
-          </li>
-        </ul>
-
-        <hr class="my-3" style="border-color: rgba(255, 255, 255, 0.2)" />
-
-        <ul class="nav flex-column">
-          <li class="nav-item">
-            <a class="nav-link" href="/auth" (click)="onLogout($event)">
-              <i class="fas fa-sign-out-alt"></i> Logout
-            </a>
-          </li>
-        </ul>
+        <app-user-menu (logout)="onLogout()"></app-user-menu>
       </div>
-    </nav>
+    </header>
 
-    <!-- Main content -->
-    <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4 main-content">
-      <router-outlet></router-outlet>
+    <main class="main-content">
+      <div class="content-shell container-xl">
+        <router-outlet></router-outlet>
+      </div>
     </main>
   </div>
 </div>

--- a/src/boardmgmt-frontend/src/app/layout/shell/shell.component.scss
+++ b/src/boardmgmt-frontend/src/app/layout/shell/shell.component.scss
@@ -1,0 +1,392 @@
+@use 'sass:color';
+
+:host {
+  display: block;
+  background: var(--light-bg);
+}
+
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  background: var(--light-bg);
+}
+
+.sidebar {
+  width: 280px;
+  background: linear-gradient(180deg, var(--primary-color) 0%, #34495e 100%);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2.5rem 2rem;
+  box-shadow: 2px 0 24px rgba(0, 0, 0, 0.12);
+  position: sticky;
+  top: 0;
+  min-height: 100vh;
+  z-index: 2;
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.sidebar__brand-icon {
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.15);
+  font-size: 1.75rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.sidebar__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.sidebar__subtitle {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.sidebar__menu {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.sidebar__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.sidebar__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.48);
+  margin-bottom: 0.5rem;
+}
+
+.sidebar__link {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  color: rgba(255, 255, 255, 0.78);
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+}
+
+.sidebar__link i {
+  width: 1.25rem;
+  text-align: center;
+}
+
+.sidebar__link:hover {
+  color: #fff;
+  transform: translateX(4px);
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.sidebar__link.is-active {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.16);
+}
+
+.sidebar__footer {
+  margin-top: auto;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  padding-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sidebar__status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.sidebar__status i {
+  font-size: 1.1rem;
+  width: 1.5rem;
+  text-align: center;
+}
+
+.sidebar__status-title {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.sidebar__status-subtitle {
+  display: block;
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.sidebar__logout {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  padding: 0.6rem 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.sidebar__logout:hover {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.4);
+  transform: translateY(-1px);
+}
+
+.app-shell__main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--light-bg);
+}
+
+.topbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1.5rem;
+  background: #fff;
+  padding: 1.75rem 2.25rem;
+  border-bottom: 1px solid var(--border-color);
+  box-shadow: var(--shadow);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.topbar__greeting {
+  max-width: 480px;
+}
+
+.topbar__eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  font-weight: 600;
+  color: var(--secondary-color);
+}
+
+.topbar__greeting h1 {
+  margin: 0.4rem 0;
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--primary-color);
+}
+
+.topbar__greeting p {
+  margin: 0;
+  color: color.mix(#fff, var(--dark-text), 20%);
+  max-width: 32rem;
+}
+
+.topbar__actions {
+  margin-left: auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 1rem;
+  min-width: 260px;
+}
+
+.topbar__search {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: var(--light-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 0.55rem 1rem;
+  min-width: 240px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.topbar__search i {
+  color: var(--secondary-color);
+}
+
+.topbar__search input {
+  border: none;
+  background: transparent;
+  outline: none;
+  width: 100%;
+  color: var(--dark-text);
+  font-size: 0.95rem;
+}
+
+.topbar__quick-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.pill-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  font-weight: 500;
+  font-size: 0.85rem;
+  text-decoration: none;
+  color: #fff;
+  background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+  box-shadow: var(--shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pill-link:hover {
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-lg);
+}
+
+.pill-link--outline {
+  background: transparent;
+  color: var(--primary-color);
+  border: 1px solid color.mix(#fff, var(--primary-color), 60%);
+  box-shadow: none;
+}
+
+.pill-link--outline:hover {
+  background: rgba(52, 152, 219, 0.12);
+  color: var(--primary-color);
+  box-shadow: none;
+}
+
+.main-content {
+  flex: 1;
+  overflow-y: auto;
+  background: var(--light-bg);
+  padding: 2rem 0 2.5rem;
+}
+
+.content-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+@media (max-width: 1200px) {
+  .sidebar {
+    width: 260px;
+    padding: 2rem 1.75rem;
+  }
+
+  .topbar {
+    padding: 1.5rem 1.75rem;
+  }
+
+  .main-content {
+    padding: 1.5rem 0 2rem;
+  }
+}
+
+@media (max-width: 992px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    position: relative;
+    width: 100%;
+    min-height: auto;
+    border-radius: 0;
+    padding: 1.75rem 1.5rem;
+    flex-direction: column;
+  }
+
+  .sidebar__footer {
+    border-top-color: rgba(255, 255, 255, 0.25);
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .sidebar__logout {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .topbar {
+    position: relative;
+  }
+}
+
+@media (max-width: 768px) {
+  .topbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .topbar__actions {
+    justify-content: flex-start;
+  }
+
+  .topbar__search {
+    width: 100%;
+  }
+
+  .topbar__quick-links {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .pill-link,
+  .pill-link--outline {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 576px) {
+  .sidebar {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .sidebar__brand {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .sidebar__brand-icon {
+    border-radius: 0.9rem;
+  }
+
+  .topbar__greeting h1 {
+    font-size: 1.6rem;
+  }
+}

--- a/src/boardmgmt-frontend/src/app/layout/shell/shell.component.ts
+++ b/src/boardmgmt-frontend/src/app/layout/shell/shell.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink, RouterLinkActive, RouterOutlet, Router } from '@angular/router';
 
+import { UserMenuComponent } from '@features/shared/user-menu/user-menu.component';
+
 import { AccessService } from '@core/services/access.service';
 import { AppModule, Permission } from '@core/models/security.models';
 import { MeService } from '@core/services/me.service';
@@ -10,7 +12,7 @@ import { BROWSER_STORAGE } from '@core/tokens/browser-storage.token';
 @Component({
   standalone: true,
   selector: 'app-shell',
-  imports: [CommonModule, RouterOutlet, RouterLink, RouterLinkActive],
+  imports: [CommonModule, RouterOutlet, RouterLink, RouterLinkActive, UserMenuComponent],
   templateUrl: './shell.component.html',
   styleUrls: ['./shell.component.scss'],
 })
@@ -35,8 +37,8 @@ export class ShellComponent implements OnInit {
     return this.access.can(module, Permission.View);
   }
 
-  onLogout(e: Event) {
-    e.preventDefault();
+  onLogout(e?: Event) {
+    e?.preventDefault();
     this.storage.removeItem('jwt');
     this.router.navigateByUrl('/auth');
   }


### PR DESCRIPTION
## Summary
- replace the old Bootstrap grid shell with a dedicated sidebar and header layout that preserves the existing colour palette
- add modern styling and responsive behaviour for the navigation shell so pages share a consistent presentation
- wire the user menu into the shell and update the logout handler so it can be triggered from multiple UI elements

## Testing
- npm install --include=dev --no-progress *(fails: 403 Forbidden downloading @angular-devkit/build-angular from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68f293d5ee888320879e8546ccb734f5