### PR TITLE
Revamp shell layout styling

### DIFF
--- a/src/boardmgmt-frontend/src/app/layout/shell/shell.component.html
+++ b/src/boardmgmt-frontend/src/app/layout/shell/shell.component.html
@@ -1,86 +1,249 @@
-<div class="container-fluid">
-  <div class="row">
-    <!-- Sidebar -->
-    <nav class="col-md-3 col-lg-2 d-md-block sidebar collapse">
-      <div class="position-sticky pt-3">
-        <div class="text-center mb-4">
-          <i class="fas fa-users-cog fa-2x text-white mb-2"></i>
-          <h5 class="text-white">Board Portal</h5>
-        </div>
+<div class="shell-layout" [class.sidebar-open]="isSidebarOpen">
+  <aside class="sidebar" role="navigation">
+    <div class="sidebar-header">
+      <div class="brand-icon">
+        <i class="fas fa-users-cog"></i>
+      </div>
+      <div class="brand-text">
+        <span class="brand-title">Board Portal</span>
+        <span class="brand-subtitle">Management Suite</span>
+      </div>
+      <button
+        type="button"
+        class="close-sidebar d-lg-none"
+        (click)="toggleSidebar()"
+        aria-label="Close navigation"
+      >
+        <i class="fas fa-times"></i>
+      </button>
+    </div>
 
+    <div class="sidebar-content">
+      <div class="nav-section">
+        <p class="nav-section-title">Overview</p>
         <ul class="nav flex-column">
           <li class="nav-item" *ngIf="can(AppModule.Dashboard)">
-            <a class="nav-link" routerLink="/dashboard" routerLinkActive="active">
-              <i class="fas fa-tachometer-alt"></i> Dashboard
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Meetings)">
-            <a class="nav-link" routerLink="/meetings" routerLinkActive="active">
-              <i class="fas fa-calendar-alt"></i> Meetings
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Documents)">
-            <a class="nav-link" routerLink="/documents" routerLinkActive="active">
-              <i class="fas fa-file-alt"></i> Documents
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Votes)">
-            <a class="nav-link" routerLink="/voting" routerLinkActive="active">
-              <i class="fas fa-vote-yea"></i> Voting
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Reports)">
-            <a class="nav-link" routerLink="/reports" routerLinkActive="active">
-              <i class="fas fa-chart-bar"></i> Reports
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Messages)">
-            <a class="nav-link" routerLink="/messages" routerLinkActive="active">
-              <i class="fas fa-comments"></i> Messages
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Users)">
-            <a class="nav-link" routerLink="/users" routerLinkActive="active">
-              <i class="fas fa-users"></i> Users
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Settings)">
-            <!-- if your Roles UI lives at /settings/roles, keep this link -->
-            <a class="nav-link" routerLink="/settings/roles" routerLinkActive="active">
-              <i class="fas fa-cog"></i> Settings
-            </a>
-          </li>
-
-          <li class="nav-item" *ngIf="can(AppModule.Settings)">
-            <!-- if your Roles UI lives at /settings/roles, keep this link -->
-            <a class="nav-link" routerLink="/roles" routerLinkActive="active">
-              <i class="fas fa-user-shield"></i> Role
-            </a>
-          </li>
-        </ul>
-
-        <hr class="my-3" style="border-color: rgba(255, 255, 255, 0.2)" />
-
-        <ul class="nav flex-column">
-          <li class="nav-item">
-            <a class="nav-link" href="/auth" (click)="onLogout($event)">
-              <i class="fas fa-sign-out-alt"></i> Logout
+            <a
+              class="nav-link"
+              routerLink="/dashboard"
+              routerLinkActive="active"
+              (click)="handleNavClick()"
+              [attr.title]="!isSidebarOpen ? 'Dashboard' : null"
+            >
+              <i class="fas fa-tachometer-alt"></i>
+              <span>Dashboard</span>
             </a>
           </li>
         </ul>
       </div>
-    </nav>
 
-    <!-- Main content -->
-    <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4 main-content">
-      <router-outlet></router-outlet>
-    </main>
+      <div class="nav-section">
+        <p class="nav-section-title">Workspace</p>
+        <ul class="nav flex-column">
+          <li class="nav-item" *ngIf="can(AppModule.Meetings)">
+            <a
+              class="nav-link"
+              routerLink="/meetings"
+              routerLinkActive="active"
+              (click)="handleNavClick()"
+              [attr.title]="!isSidebarOpen ? 'Meetings' : null"
+            >
+              <i class="fas fa-calendar-alt"></i>
+              <span>Meetings</span>
+            </a>
+          </li>
+
+          <li class="nav-item" *ngIf="can(AppModule.Documents)">
+            <a
+              class="nav-link"
+              routerLink="/documents"
+              routerLinkActive="active"
+              (click)="handleNavClick()"
+              [attr.title]="!isSidebarOpen ? 'Documents' : null"
+            >
+              <i class="fas fa-file-alt"></i>
+              <span>Documents</span>
+            </a>
+          </li>
+
+          <li class="nav-item" *ngIf="can(AppModule.Votes)">
+            <a
+              class="nav-link"
+              routerLink="/voting"
+              routerLinkActive="active"
+              (click)="handleNavClick()"
+              [attr.title]="!isSidebarOpen ? 'Voting' : null"
+            >
+              <i class="fas fa-vote-yea"></i>
+              <span>Voting</span>
+            </a>
+          </li>
+
+          <li class="nav-item" *ngIf="can(AppModule.Reports)">
+            <a
+              class="nav-link"
+              routerLink="/reports"
+              routerLinkActive="active"
+              (click)="handleNavClick()"
+              [attr.title]="!isSidebarOpen ? 'Reports' : null"
+            >
+              <i class="fas fa-chart-bar"></i>
+              <span>Reports</span>
+            </a>
+          </li>
+
+          <li class="nav-item" *ngIf="can(AppModule.Messages)">
+            <a
+              class="nav-link"
+              routerLink="/messages"
+              routerLinkActive="active"
+              (click)="handleNavClick()"
+              [attr.title]="!isSidebarOpen ? 'Messages' : null"
+            >
+              <i class="fas fa-comments"></i>
+              <span>Messages</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <div class="nav-section">
+        <p class="nav-section-title">Administration</p>
+        <ul class="nav flex-column">
+          <li class="nav-item" *ngIf="can(AppModule.Users)">
+            <a
+              class="nav-link"
+              routerLink="/users"
+              routerLinkActive="active"
+              (click)="handleNavClick()"
+              [attr.title]="!isSidebarOpen ? 'Users' : null"
+            >
+              <i class="fas fa-users"></i>
+              <span>Users</span>
+            </a>
+          </li>
+
+          <li class="nav-item" *ngIf="can(AppModule.Settings)">
+            <a
+              class="nav-link"
+              routerLink="/settings/roles"
+              routerLinkActive="active"
+              (click)="handleNavClick()"
+              [attr.title]="!isSidebarOpen ? 'Settings' : null"
+            >
+              <i class="fas fa-cog"></i>
+              <span>Settings</span>
+            </a>
+          </li>
+
+          <li class="nav-item" *ngIf="can(AppModule.Settings)">
+            <a
+              class="nav-link"
+              routerLink="/roles"
+              routerLinkActive="active"
+              (click)="handleNavClick()"
+              [attr.title]="!isSidebarOpen ? 'Role' : null"
+            >
+              <i class="fas fa-user-shield"></i>
+              <span>Role</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="sidebar-footer">
+      <div class="support-card">
+        <div class="support-icon">
+          <i class="fas fa-life-ring"></i>
+        </div>
+        <div>
+          <p class="support-title mb-1">Need assistance?</p>
+          <p class="support-text mb-2">Explore resources curated for board members.</p>
+          <a class="support-link" href="mailto:support@boardportal.com">support@boardportal.com</a>
+        </div>
+      </div>
+      <a class="nav-link logout" href="/auth" (click)="onLogout($event); handleNavClick()">
+        <i class="fas fa-sign-out-alt"></i>
+        <span>Logout</span>
+      </a>
+    </div>
+  </aside>
+
+  <div
+    class="sidebar-backdrop"
+    *ngIf="isSidebarOpen && viewportWidth < 992"
+    (click)="toggleSidebar()"
+  ></div>
+
+  <div class="content-area">
+    <header class="topbar">
+      <div class="topbar-left">
+        <button type="button" class="menu-toggle" (click)="toggleSidebar()" aria-label="Toggle navigation">
+          <i class="fas fa-bars"></i>
+        </button>
+        <div class="page-meta">
+          <p class="page-subtitle">Board Management Portal</p>
+          <h1 class="page-title">{{ activeSection }}</h1>
+          <nav class="breadcrumbs" aria-label="Breadcrumb">
+            <ol>
+              <li *ngFor="let crumb of breadcrumbs; let last = last" [class.active]="last">
+                <span>{{ crumb }}</span>
+                <i class="fas fa-chevron-right" *ngIf="!last"></i>
+              </li>
+            </ol>
+          </nav>
+        </div>
+      </div>
+      <div class="topbar-right">
+        <div class="search-group d-none d-md-flex">
+          <i class="fas fa-search"></i>
+          <input type="text" placeholder="Search modules" aria-label="Search modules" />
+        </div>
+        <div class="topbar-actions">
+          <button type="button" class="btn btn-primary btn-sm shadow-sm">
+            <i class="fas fa-plus-circle"></i>
+            <span class="d-none d-xl-inline">New Meeting</span>
+          </button>
+          <button type="button" class="btn btn-outline-primary btn-sm shadow-sm d-none d-lg-inline-flex">
+            <i class="fas fa-upload"></i>
+            Upload
+          </button>
+        </div>
+        <div class="profile-chip">
+          <i class="fas fa-user-circle"></i>
+          <div>
+            <span class="name">Administrator</span>
+            <small>Board Member</small>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <section class="content-main">
+      <div class="content-intro">
+        <div class="intro-text">
+          <h2>Welcome back!</h2>
+          <p class="mb-0">
+            You're currently in the {{ activeSection | lowercase }} workspace. Stay organized and
+            keep board collaboration moving forward.
+          </p>
+        </div>
+        <div class="intro-actions">
+          <button type="button" class="btn btn-light btn-sm">
+            <i class="fas fa-calendar-check"></i>
+            Upcoming Meetings
+          </button>
+          <button type="button" class="btn btn-light btn-sm">
+            <i class="fas fa-file-alt"></i>
+            Recent Documents
+          </button>
+        </div>
+      </div>
+
+      <div class="content-body">
+        <router-outlet></router-outlet>
+      </div>
+    </section>
   </div>
 </div>

--- a/src/boardmgmt-frontend/src/app/layout/shell/shell.component.scss
+++ b/src/boardmgmt-frontend/src/app/layout/shell/shell.component.scss
@@ -1,0 +1,470 @@
+:host {
+  display: block;
+  color: var(--dark-text);
+}
+
+.shell-layout {
+  position: relative;
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  background: var(--light-bg);
+  transition: grid-template-columns 0.3s ease;
+}
+
+.shell-layout:not(.sidebar-open) {
+  grid-template-columns: 88px minmax(0, 1fr);
+}
+
+.sidebar {
+  background: linear-gradient(180deg, var(--primary-color) 0%, #34495e 100%);
+  padding: 2rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  box-shadow: 2px 0 15px rgba(44, 62, 80, 0.2);
+  position: relative;
+  z-index: 999;
+  transition: padding 0.3s ease;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.1);
+  display: grid;
+  place-items: center;
+  font-size: 1.5rem;
+  color: white;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.18);
+}
+
+.brand-text {
+  display: flex;
+  flex-direction: column;
+  color: white;
+}
+
+.brand-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.brand-subtitle {
+  font-size: 0.75rem;
+  opacity: 0.7;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.close-sidebar {
+  margin-left: auto;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 1.25rem;
+}
+
+.sidebar-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.nav-section-title {
+  margin-bottom: 0.5rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.sidebar .nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  color: rgba(255, 255, 255, 0.75);
+  padding: 0.75rem 1rem;
+  margin: 0.2rem 0;
+  border-radius: 0.75rem;
+  font-weight: 500;
+  transition: all 0.3s ease;
+}
+
+.sidebar .nav-link i {
+  font-size: 1rem;
+  width: 1.5rem;
+  text-align: center;
+}
+
+.sidebar .nav-link:hover,
+.sidebar .nav-link.active {
+  color: white;
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateX(4px);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.12);
+}
+
+.sidebar-footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  padding-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.support-card {
+  display: flex;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  color: white;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.support-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.18);
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+}
+
+.support-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.support-text {
+  font-size: 0.75rem;
+  opacity: 0.75;
+}
+
+.support-link {
+  font-size: 0.8rem;
+  color: white;
+  font-weight: 600;
+}
+
+.sidebar-footer .logout {
+  justify-content: flex-start;
+  background: rgba(231, 76, 60, 0.1);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.sidebar-footer .logout:hover {
+  background: rgba(231, 76, 60, 0.22);
+}
+
+.sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(44, 62, 80, 0.45);
+  backdrop-filter: blur(2px);
+  z-index: 998;
+}
+
+.content-area {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--light-bg);
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.5rem 2rem;
+  background: white;
+  border-bottom: 1px solid var(--border-color);
+  box-shadow: var(--shadow);
+}
+
+.topbar-left {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.menu-toggle {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+  color: white;
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+  box-shadow: 0 12px 24px rgba(44, 62, 80, 0.25);
+}
+
+.page-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.page-subtitle {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  color: var(--secondary-color);
+  margin: 0;
+}
+
+.page-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--primary-color);
+}
+
+.breadcrumbs ol {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  font-size: 0.8rem;
+  color: rgba(44, 62, 80, 0.6);
+}
+
+.breadcrumbs li {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.breadcrumbs li.active span {
+  font-weight: 600;
+  color: var(--primary-color);
+}
+
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.search-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  background: var(--light-bg);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  border: 1px solid var(--border-color);
+}
+
+.search-group input {
+  border: none;
+  background: transparent;
+  font-size: 0.85rem;
+  outline: none;
+  min-width: 160px;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.profile-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(44, 62, 80, 0.08), rgba(52, 152, 219, 0.12));
+  border: 1px solid rgba(44, 62, 80, 0.08);
+}
+
+.profile-chip i {
+  font-size: 1.75rem;
+  color: var(--primary-color);
+}
+
+.profile-chip .name {
+  font-weight: 600;
+  display: block;
+}
+
+.profile-chip small {
+  font-size: 0.7rem;
+  color: rgba(44, 62, 80, 0.65);
+}
+
+.content-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+}
+
+.content-intro {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: white;
+  border-radius: 1.5rem;
+  padding: 1.5rem 2rem;
+  box-shadow: var(--shadow);
+  border-left: 4px solid var(--secondary-color);
+}
+
+.content-intro h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: var(--primary-color);
+}
+
+.content-intro p {
+  color: rgba(44, 62, 80, 0.7);
+}
+
+.intro-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.content-body {
+  flex: 1;
+  background: white;
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow-lg);
+  padding: 2rem;
+  min-height: calc(100vh - 260px);
+}
+
+.shell-layout:not(.sidebar-open) .sidebar {
+  padding: 2rem 0.75rem;
+}
+
+.shell-layout:not(.sidebar-open) .brand-text,
+.shell-layout:not(.sidebar-open) .nav-section-title,
+.shell-layout:not(.sidebar-open) .support-card,
+.shell-layout:not(.sidebar-open) .sidebar-footer .logout span {
+  display: none;
+}
+
+.shell-layout:not(.sidebar-open) .sidebar .nav-link {
+  justify-content: center;
+  padding: 0.75rem;
+}
+
+.shell-layout:not(.sidebar-open) .sidebar .nav-link span {
+  display: none;
+}
+
+.shell-layout:not(.sidebar-open) .sidebar-footer {
+  align-items: center;
+}
+
+@media (max-width: 1199.98px) {
+  .topbar {
+    padding: 1.25rem 1.5rem;
+  }
+
+  .content-main {
+    padding: 1.5rem;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .shell-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .shell-layout:not(.sidebar-open) {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: 260px;
+    transform: translateX(-100%);
+    height: 100vh;
+    padding: 2rem 1.5rem;
+    box-shadow: 20px 0 45px rgba(0, 0, 0, 0.2);
+  }
+
+  .shell-layout.sidebar-open .sidebar {
+    transform: translateX(0);
+  }
+
+  .shell-layout:not(.sidebar-open) .sidebar {
+    transform: translateX(-100%);
+  }
+
+  .menu-toggle {
+    width: 40px;
+    height: 40px;
+  }
+
+  .topbar-right {
+    gap: 0.75rem;
+  }
+
+  .content-intro {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .content-body {
+    padding: 1.25rem;
+    min-height: unset;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .topbar-right {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .search-group {
+    display: none !important;
+  }
+
+  .intro-actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .content-main {
+    padding: 1rem;
+  }
+
+  .content-body {
+    padding: 1rem;
+  }
+}

--- a/src/boardmgmt-frontend/src/app/layout/shell/shell.component.ts
+++ b/src/boardmgmt-frontend/src/app/layout/shell/shell.component.ts
@@ -1,11 +1,19 @@
-import { Component, OnInit, inject } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  inject,
+  DestroyRef,
+  HostListener,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterLink, RouterLinkActive, RouterOutlet, Router } from '@angular/router';
+import { RouterLink, RouterLinkActive, RouterOutlet, Router, NavigationEnd } from '@angular/router';
 
 import { AccessService } from '@core/services/access.service';
 import { AppModule, Permission } from '@core/models/security.models';
 import { MeService } from '@core/services/me.service';
 import { BROWSER_STORAGE } from '@core/tokens/browser-storage.token';
+import { filter } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
   standalone: true,
@@ -19,13 +27,32 @@ export class ShellComponent implements OnInit {
   AppModule = AppModule;
   Permission = Permission;
 
+  // layout state
+  isSidebarOpen = true;
+  viewportWidth = 1200;
+  activeSection = 'Dashboard';
+  breadcrumbs: string[] = ['Dashboard'];
+
   // DI (Angular 17 style)
   private me = inject(MeService);
   private access = inject(AccessService);
   private storage = inject(BROWSER_STORAGE);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
+    this.viewportWidth = this.getViewportWidth();
+    this.isSidebarOpen = this.viewportWidth >= 992;
+
+    this.router.events
+      .pipe(
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((event) => this.updateNavigationState(event.urlAfterRedirects));
+
+    this.updateNavigationState(this.router.url);
+
     // load once; MeService is idempotent
     this.me.loadPermissions();
   }
@@ -35,9 +62,58 @@ export class ShellComponent implements OnInit {
     return this.access.can(module, Permission.View);
   }
 
+  toggleSidebar() {
+    if (this.viewportWidth < 992) {
+      this.isSidebarOpen = !this.isSidebarOpen;
+      return;
+    }
+
+    this.isSidebarOpen = !this.isSidebarOpen;
+  }
+
+  handleNavClick() {
+    if (this.viewportWidth < 992) {
+      this.isSidebarOpen = false;
+    }
+  }
+
   onLogout(e: Event) {
     e.preventDefault();
     this.storage.removeItem('jwt');
     this.router.navigateByUrl('/auth');
+  }
+
+  @HostListener('window:resize')
+  onWindowResize() {
+    this.viewportWidth = this.getViewportWidth();
+
+    if (this.viewportWidth >= 992) {
+      this.isSidebarOpen = true;
+    }
+  }
+
+  private updateNavigationState(url: string) {
+    const sanitized = url.split('?')[0];
+    const segments = sanitized.split('/').filter(Boolean);
+
+    if (!segments.length || segments[0] === 'dashboard') {
+      this.activeSection = 'Dashboard';
+      this.breadcrumbs = ['Dashboard'];
+      return;
+    }
+
+    this.activeSection = this.formatLabel(segments[segments.length - 1]);
+    this.breadcrumbs = segments.map((segment) => this.formatLabel(segment));
+  }
+
+  private formatLabel(value: string) {
+    return value
+      .split('-')
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ');
+  }
+
+  private getViewportWidth(): number {
+    return typeof window !== 'undefined' ? window.innerWidth : 1200;
   }
 }


### PR DESCRIPTION
## Summary
- redesign the application shell with a structured sidebar, top navigation, and content surface without altering the existing color palette
- add responsive behavior including sidebar toggling, route-aware breadcrumbs, and mobile backdrop handling
- craft component-scoped styling for the refreshed layout, including quick actions and profile chip accents

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f2986556d48320b930f10c6b0b9c7a