### PR TITLE
Create reusable page header component for feature pages

### DIFF
--- a/src/boardmgmt-frontend/src/app/features/dashboard/dashboard.page.html
+++ b/src/boardmgmt-frontend/src/app/features/dashboard/dashboard.page.html
@@ -1,14 +1,10 @@
 <!-- src/app/features/dashboard/dashboard.page.html -->
 
-<!-- Top Navigation -->
-<div
-  class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 top-navbar"
->
-  <h1 class="h2">Dashboard</h1>
-  <div class="btn-toolbar mb-2 mb-md-0">
-   <app-user-menu [displayName]="'John Doe'" (logout)="onLogout()"></app-user-menu>
+<app-page-header title="Dashboard">
+  <div pageHeaderActions class="btn-toolbar mb-2 mb-md-0">
+    <app-user-menu [displayName]="'John Doe'" (logout)="onLogout()"></app-user-menu>
   </div>
-</div>
+</app-page-header>
 
 <div *ngIf="error()" class="alert alert-danger py-2">{{ error() }}</div>
 

--- a/src/boardmgmt-frontend/src/app/features/dashboard/dashboard.page.ts
+++ b/src/boardmgmt-frontend/src/app/features/dashboard/dashboard.page.ts
@@ -22,6 +22,7 @@ import { CreateVoteModal } from '../shared/create-vote-modal/create-vote.modal';
 import { StatsDetailModalComponent } from '../shared/stats-detail-modal/stats-detail-modal.component';
 import { StatsKind } from './dashboard.api';
 import { UserMenuComponent } from '../shared/user-menu/user-menu.component';
+import { PageHeaderComponent } from '../shared/page-header/page-header.component';
 
 
 // Meetings feature to fetch full meeting & transcripts
@@ -44,7 +45,8 @@ import { Router } from '@angular/router';
     UploadDocumentModal,
     CreateVoteModal,
     StatsDetailModalComponent,
-    UserMenuComponent
+    UserMenuComponent,
+    PageHeaderComponent,
   ],
   templateUrl: './dashboard.page.html',
   styleUrls: ['./dashboard.page.scss'],

--- a/src/boardmgmt-frontend/src/app/features/documents/documents.page.html
+++ b/src/boardmgmt-frontend/src/app/features/documents/documents.page.html
@@ -1,9 +1,5 @@
-<!-- Top Navigation -->
-<div
-  class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 top-navbar"
->
-  <h1 class="h2">Documents</h1>
-  <div class="btn-toolbar mb-2 mb-md-0">
+<app-page-header title="Documents">
+  <div pageHeaderActions class="btn-toolbar mb-2 mb-md-0">
     <div class="btn-group me-2">
       <button type="button" class="btn btn-primary" (click)="openUpload()">
         <i class="fas fa-upload"></i> Upload Document
@@ -14,7 +10,7 @@
     </div>
     <app-user-menu [displayName]="'John Doe'" (logout)="onLogout()"></app-user-menu>
   </div>
-</div>
+</app-page-header>
 
 <!-- Filters -->
 <div class="row mb-4">

--- a/src/boardmgmt-frontend/src/app/features/documents/documents.page.ts
+++ b/src/boardmgmt-frontend/src/app/features/documents/documents.page.ts
@@ -12,6 +12,7 @@ import {
   DatePreset,
 } from '@core/services/documents.service';
 import { UserMenuComponent } from '../shared/user-menu/user-menu.component';
+import { PageHeaderComponent } from '../shared/page-header/page-header.component';
 
 declare global {
   interface Window {
@@ -31,6 +32,7 @@ type FolderStyle = { colorClass: string; iconClass: string };
     NewFolderModal,
     DocumentViewerModalComponent,
     UserMenuComponent,
+    PageHeaderComponent,
   ],
   templateUrl: './documents.page.html',
   styleUrls: ['./documents.page.scss'],

--- a/src/boardmgmt-frontend/src/app/features/meetings/calendar/calendar.page.html
+++ b/src/boardmgmt-frontend/src/app/features/meetings/calendar/calendar.page.html
@@ -1,11 +1,8 @@
-<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 top-navbar">
-  <h1 class="h2">Meetings</h1>
-  <div class="btn-toolbar mb-2 mb-md-0">
-    
-
-   <app-user-menu [displayName]="'John Doe'" (logout)="onLogout()"></app-user-menu>
+<app-page-header title="Meetings">
+  <div pageHeaderActions class="btn-toolbar mb-2 mb-md-0">
+    <app-user-menu [displayName]="'John Doe'" (logout)="onLogout()"></app-user-menu>
   </div>
-</div>
+</app-page-header>
 
 <div class="outlook-cal">
   <!-- Toolbar -->

--- a/src/boardmgmt-frontend/src/app/features/meetings/calendar/calendar.page.ts
+++ b/src/boardmgmt-frontend/src/app/features/meetings/calendar/calendar.page.ts
@@ -26,6 +26,7 @@ import { CalendarApiService, CalendarEventDto } from './calendar-api.service';
 import { ScheduleMeetingModal } from '../../shared/schedule-meeting-modal/schedule-meeting.modal';
 import { MeetingsService, MeetingDto } from '../../meetings/meetings.service';
 import { UserMenuComponent } from '@app/features/shared/user-menu/user-menu.component';
+import { PageHeaderComponent } from '@app/features/shared/page-header/page-header.component';
 
 type Provider = 'Zoom' | 'Microsoft365' | 'All';
 type EventMeta = { id: string; joinUrl?: string | null; provider?: Provider | null };
@@ -47,6 +48,7 @@ const colors = {
     DragAndDropModule,
     ScheduleMeetingModal,
     UserMenuComponent,
+    PageHeaderComponent,
   ],
   templateUrl: './calendar.page.html',
   styleUrls: ['./calendar.page.scss'],

--- a/src/boardmgmt-frontend/src/app/features/meetings/meetings.page.html
+++ b/src/boardmgmt-frontend/src/app/features/meetings/meetings.page.html
@@ -1,7 +1,5 @@
-<!-- Top Navigation -->
-<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 top-navbar">
-  <h1 class="h2">Meetings</h1>
-  <div class="btn-toolbar mb-2 mb-md-0">
+<app-page-header title="Meetings">
+  <div pageHeaderActions class="btn-toolbar mb-2 mb-md-0">
     <div class="btn-group me-2">
       <button type="button" class="btn btn-primary" (click)="createModal.open()">
         <i class="fas fa-plus"></i> New Meeting
@@ -11,9 +9,9 @@
       </button>
     </div>
 
-   <app-user-menu [displayName]="'John Doe'" (logout)="onLogout()"></app-user-menu>
+    <app-user-menu [displayName]="'John Doe'" (logout)="onLogout()"></app-user-menu>
   </div>
-</div>
+</app-page-header>
 
 <!-- Meeting Filters -->
 <div class="row mb-4">

--- a/src/boardmgmt-frontend/src/app/features/meetings/meetings.page.ts
+++ b/src/boardmgmt-frontend/src/app/features/meetings/meetings.page.ts
@@ -5,6 +5,7 @@ import { Router } from '@angular/router';
 import { MeetingsService, MeetingDto, MeetingStatus, TranscriptDto } from './meetings.service';
 import { ScheduleMeetingModal } from '../shared/schedule-meeting-modal/schedule-meeting.modal';
 import { UserMenuComponent } from '../shared/user-menu/user-menu.component';
+import { PageHeaderComponent } from '../shared/page-header/page-header.component';
 
 declare const bootstrap: any;
 
@@ -45,7 +46,17 @@ export class TimeSpanPipe implements PipeTransform {
 @Component({
   standalone: true,
   selector: 'app-meetings',
-  imports: [CommonModule, FormsModule, DatePipe, ScheduleMeetingModal, OrderByPipe, InitialsPipe, TimeSpanPipe,UserMenuComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    DatePipe,
+    ScheduleMeetingModal,
+    OrderByPipe,
+    InitialsPipe,
+    TimeSpanPipe,
+    UserMenuComponent,
+    PageHeaderComponent,
+  ],
   templateUrl: './meetings.page.html',
   styleUrls: ['./meetings.page.scss'],
 })

--- a/src/boardmgmt-frontend/src/app/features/messages/messages.page.html
+++ b/src/boardmgmt-frontend/src/app/features/messages/messages.page.html
@@ -1,13 +1,12 @@
-<div class="d-flex justify-content-between align-items-center pt-3 pb-2 mb-3 top-navbar">
-  <h1 class="h2">Messages</h1>
-  <div class="btn-toolbar">
+<app-page-header title="Messages">
+  <div pageHeaderActions class="btn-toolbar">
     <div class="btn-group">
       <button type="button" class="btn btn-primary" (click)="openCompose()">
         <i class="fas fa-plus"></i> New Message
       </button>
     </div>
   </div>
-</div>
+</app-page-header>
 
 <div class="row g-2 mb-3">
   <div class="col-md-4">

--- a/src/boardmgmt-frontend/src/app/features/messages/messages.page.ts
+++ b/src/boardmgmt-frontend/src/app/features/messages/messages.page.ts
@@ -11,12 +11,13 @@ import {
   MinimalUserDto,
 } from './messages.models';
 import { NewMessageModalComponent } from '../shared/new-message-modal/new-message-modal.component';
+import { PageHeaderComponent } from '../shared/page-header/page-header.component';
 import { ToastrService } from 'ngx-toastr';
 
 @Component({
   standalone: true,
   selector: 'app-messages',
-  imports: [CommonModule, FormsModule, NgIf, NgFor, NgClass, NewMessageModalComponent],
+  imports: [CommonModule, FormsModule, NgIf, NgFor, NgClass, NewMessageModalComponent, PageHeaderComponent],
   templateUrl: './messages.page.html',
   styleUrls: ['./messages.page.scss'],
 })

--- a/src/boardmgmt-frontend/src/app/features/reports/reports.page.html
+++ b/src/boardmgmt-frontend/src/app/features/reports/reports.page.html
@@ -1,7 +1,5 @@
-<!-- Top Navigation -->
-<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 top-navbar">
-  <h1 class="h2">Reports & Analytics</h1>
-  <div class="btn-toolbar mb-2 mb-md-0">
+<app-page-header title="Reports &amp; Analytics">
+  <div pageHeaderActions class="btn-toolbar mb-2 mb-md-0">
     <div class="btn-group me-2">
       <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#reportGeneratorModal">
         <i class="fas fa-plus"></i> Generate Report
@@ -10,9 +8,9 @@
         <i class="fas fa-download"></i> Export Data
       </button>
     </div>
-     <app-user-menu [displayName]="'John Doe'" (logout)="onLogout()"></app-user-menu>
+    <app-user-menu [displayName]="'John Doe'" (logout)="onLogout()"></app-user-menu>
   </div>
-</div>
+</app-page-header>
 
 <!-- Report Categories -->
 <div class="row mb-4">

--- a/src/boardmgmt-frontend/src/app/features/reports/reports.page.ts
+++ b/src/boardmgmt-frontend/src/app/features/reports/reports.page.ts
@@ -19,13 +19,14 @@ import {
 import { GenerateReportModal } from '../shared/generate-report-modal/generate-report.modal';
 import { BROWSER_STORAGE } from '@core/tokens/browser-storage.token';
 import { UserMenuComponent } from '../shared/user-menu/user-menu.component';
+import { PageHeaderComponent } from '../shared/page-header/page-header.component';
 
 declare const bootstrap: any;
 
 @Component({
   standalone: true,
   selector: 'app-reports',
-  imports: [CommonModule, GenerateReportModal,UserMenuComponent],
+  imports: [CommonModule, GenerateReportModal, UserMenuComponent, PageHeaderComponent],
   templateUrl: './reports.page.html',
   styleUrls: ['./reports.page.scss'],
 })

--- a/src/boardmgmt-frontend/src/app/features/roles/create-role/create-role.component.html
+++ b/src/boardmgmt-frontend/src/app/features/roles/create-role/create-role.component.html
@@ -1,16 +1,12 @@
-<!-- Top Navigation -->
-<div
-  class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 top-navbar"
->
-  <h1 class="h2">Assign Permission</h1>
-  <div class="btn-toolbar mb-2 mb-md-0">
+<app-page-header title="Assign Permission">
+  <div pageHeaderActions class="btn-toolbar mb-2 mb-md-0">
     <div class="btn-group me-2">
       <button type="button" class="btn btn-outline-secondary" (click)="goBack()">
         <i class="fas fa-arrow-left me-1"></i> Back
       </button>
     </div>
   </div>
-</div>
+</app-page-header>
 
 <div class="page-container">
   <div class="page-container-content">

--- a/src/boardmgmt-frontend/src/app/features/roles/create-role/create-role.component.ts
+++ b/src/boardmgmt-frontend/src/app/features/roles/create-role/create-role.component.ts
@@ -4,6 +4,8 @@ import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 
+import { PageHeaderComponent } from '../../shared/page-header/page-header.component';
+
 import { MODULES, Permission, AppModule, toggleFlag } from '@core/models/security.models';
 import { RolesService, PermissionDto } from '@core/services/roles.service';
 import { MeService } from '@core/services/me.service';
@@ -33,7 +35,7 @@ const PERM_ORDER: { key: Permission; label: string }[] = [
 @Component({
   selector: 'app-create-role',
   standalone: true,
- imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PageHeaderComponent],
   templateUrl: './create-role.component.html',
   styleUrls: ['./create-role.component.scss'],
 })

--- a/src/boardmgmt-frontend/src/app/features/roles/roles.page.html
+++ b/src/boardmgmt-frontend/src/app/features/roles/roles.page.html
@@ -1,9 +1,5 @@
-<!-- Top Navigation -->
-<div
-  class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 top-navbar"
->
-  <h1 class="h2">Role</h1>
-  <div class="btn-toolbar mb-2 mb-md-0">
+<app-page-header title="Role">
+  <div pageHeaderActions class="btn-toolbar mb-2 mb-md-0">
     <div class="btn-group me-2">
       <button class="btn btn-primary" [routerLink]="['/roles/create-role']">
         <i class="fas fa-plus"></i> Create Role
@@ -11,7 +7,7 @@
     </div>
     <app-user-menu [displayName]="'John Doe'" (logout)="onLogout()"></app-user-menu>
   </div>
-</div>
+</app-page-header>
 
 <!-- Role list -->
 <div class="row">

--- a/src/boardmgmt-frontend/src/app/features/roles/roles.page.ts
+++ b/src/boardmgmt-frontend/src/app/features/roles/roles.page.ts
@@ -5,11 +5,12 @@ import { RouterLink } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { RolesService, RoleListItem } from '@core/services/roles.service';
 import { UserMenuComponent } from '../shared/user-menu/user-menu.component';
+import { PageHeaderComponent } from '../shared/page-header/page-header.component';
 
 @Component({
   standalone: true,
   selector: 'app-roles',
-  imports: [CommonModule, FormsModule, RouterLink,UserMenuComponent],
+  imports: [CommonModule, FormsModule, RouterLink, UserMenuComponent, PageHeaderComponent],
   templateUrl: './roles.page.html',
   styleUrls: ['./roles.page.scss'],
 })

--- a/src/boardmgmt-frontend/src/app/features/shared/page-header/page-header.component.html
+++ b/src/boardmgmt-frontend/src/app/features/shared/page-header/page-header.component.html
@@ -1,0 +1,9 @@
+<div
+  class="page-header d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 top-navbar"
+>
+  <div class="page-header__title">
+    <h1 class="h2 mb-0">{{ title }}</h1>
+    <p *ngIf="hasDescription" class="text-muted small mb-0">{{ description }}</p>
+  </div>
+  <ng-content select="[pageHeaderActions]"></ng-content>
+</div>

--- a/src/boardmgmt-frontend/src/app/features/shared/page-header/page-header.component.scss
+++ b/src/boardmgmt-frontend/src/app/features/shared/page-header/page-header.component.scss
@@ -1,0 +1,15 @@
+:host {
+  display: block;
+}
+
+.page-header__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+@media (max-width: 767.98px) {
+  .page-header {
+    gap: 1rem;
+  }
+}

--- a/src/boardmgmt-frontend/src/app/features/shared/page-header/page-header.component.ts
+++ b/src/boardmgmt-frontend/src/app/features/shared/page-header/page-header.component.ts
@@ -1,0 +1,18 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-page-header',
+  imports: [CommonModule],
+  templateUrl: './page-header.component.html',
+  styleUrls: ['./page-header.component.scss'],
+})
+export class PageHeaderComponent {
+  @Input() title = '';
+  @Input() description?: string;
+
+  get hasDescription(): boolean {
+    return !!this.description?.trim();
+  }
+}

--- a/src/boardmgmt-frontend/src/app/features/users/users.page.html
+++ b/src/boardmgmt-frontend/src/app/features/users/users.page.html
@@ -1,7 +1,5 @@
-<!-- Top Navigation -->
-<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 top-navbar">
-  <h1 class="h2">User Management</h1>
-  <div class="btn-toolbar mb-2 mb-md-0">
+<app-page-header title="User Management">
+  <div pageHeaderActions class="btn-toolbar mb-2 mb-md-0">
     <div class="btn-group me-2">
       <button type="button" class="btn btn-primary" (click)="openCreate()">
         <i class="fas fa-plus"></i> Add User
@@ -12,7 +10,7 @@
     </div>
     <app-user-menu [displayName]="'John Doe'" (logout)="onLogout()"></app-user-menu>
   </div>
-</div>
+</app-page-header>
 
 <!-- Stats -->
 <div class="row mb-4">

--- a/src/boardmgmt-frontend/src/app/features/users/users.page.ts
+++ b/src/boardmgmt-frontend/src/app/features/users/users.page.ts
@@ -4,13 +4,14 @@ import { FormsModule } from '@angular/forms';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { UsersService, UserDto, RoleOption, DepartmentDto } from './users.service';
 import { UserMenuComponent } from '../shared/user-menu/user-menu.component';
+import { PageHeaderComponent } from '../shared/page-header/page-header.component';
 
 declare const bootstrap: any;
 
 @Component({
   standalone: true,
   selector: 'app-users',
-  imports: [CommonModule, FormsModule, NgSelectModule,UserMenuComponent],
+  imports: [CommonModule, FormsModule, NgSelectModule, UserMenuComponent, PageHeaderComponent],
   templateUrl: './users.page.html',
   styleUrls: ['./users.page.scss'],
 })

--- a/src/boardmgmt-frontend/src/app/features/voting/voting.page.html
+++ b/src/boardmgmt-frontend/src/app/features/voting/voting.page.html
@@ -1,7 +1,5 @@
-<!-- Top Navigation -->
-<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 top-navbar">
-  <h1 class="h2">Voting</h1>
-  <div class="btn-toolbar mb-2 mb-md-0">
+<app-page-header title="Voting">
+  <div pageHeaderActions class="btn-toolbar mb-2 mb-md-0">
     <div class="btn-group me-2">
       <button type="button" class="btn btn-primary" (click)="openVoteModal()">
         <i class="fas fa-plus"></i> Create Vote
@@ -9,7 +7,7 @@
     </div>
     <app-user-menu [displayName]="'John Doe'" (logout)="onLogout()"></app-user-menu>
   </div>
-</div>
+</app-page-header>
 
 <!-- Voting Stats -->
 <div class="row mb-4">

--- a/src/boardmgmt-frontend/src/app/features/voting/voting.page.ts
+++ b/src/boardmgmt-frontend/src/app/features/voting/voting.page.ts
@@ -10,6 +10,7 @@ import {
 import { CreateVoteModal } from '../shared/create-vote-modal/create-vote.modal';
 import { ShowVoteModal } from '../shared/show-vote-modal/show-vote.modal';
 import { UserMenuComponent } from '../shared/user-menu/user-menu.component';
+import { PageHeaderComponent } from '../shared/page-header/page-header.component';
 
 interface VoteTallies {
   totalBallots: number;
@@ -22,7 +23,7 @@ interface VoteTallies {
 @Component({
   standalone: true,
   selector: 'app-voting',
-  imports: [CommonModule, FormsModule, CreateVoteModal, ShowVoteModal,UserMenuComponent],
+  imports: [CommonModule, FormsModule, CreateVoteModal, ShowVoteModal, UserMenuComponent, PageHeaderComponent],
   templateUrl: './voting.page.html',
   styleUrls: ['./voting.page.scss'],
 })


### PR DESCRIPTION
## Summary
- add a standalone page header component that encapsulates the existing layout and styling
- replace duplicated top navigation markup across dashboard, content, meetings, messaging, reporting, and role pages with the new component while preserving colors

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f3266b74048320b78d895e3819b952