### PR TITLE
Fix SQL Server connection string to use SQL authentication

### DIFF
--- a/src/BoardMgmt.Infrastructure/DependencyInjection.cs
+++ b/src/BoardMgmt.Infrastructure/DependencyInjection.cs
@@ -42,7 +42,7 @@ namespace BoardMgmt.Infrastructure
 
             // --- Connection string (fallback safe for local dev) ---
             var cs = config.GetConnectionString("DefaultConnection")
-                     ?? "Server=localhost\\SQLEXPRESS;Database=BoardMgmtDb;Trusted_Connection=True;TrustServerCertificate=True;MultipleActiveResultSets=True";
+                     ?? "Server=localhost\\SQLEXPRESS;Database=BoardMgmtDb;Trusted_Connection=False;TrustServerCertificate=True;MultipleActiveResultSets=True";
 
             // --- DbContext with robust SQL Server + logging setup ---
             services.AddDbContext<AppDbContext>((sp, options) =>

--- a/src/BoardMgmt.Infrastructure/Persistence/AppDbContextFactory.cs
+++ b/src/BoardMgmt.Infrastructure/Persistence/AppDbContextFactory.cs
@@ -21,7 +21,7 @@ public sealed class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbConte
             .Build();
 
         var cs = config.GetConnectionString("DefaultConnection")
-                 ?? "Server=localhost\\SQLEXPRESS;Database=BoardMgmtDb;Trusted_Connection=True;TrustServerCertificate=True;MultipleActiveResultSets=True";
+                 ?? "Server=localhost\\SQLEXPRESS;Database=BoardMgmtDb;Trusted_Connection=False;TrustServerCertificate=True;MultipleActiveResultSets=True";
 
         var options = new DbContextOptionsBuilder<AppDbContext>()
             .UseSqlServer(cs)

--- a/src/BoardMgmt.WebApi/appsettings.json
+++ b/src/BoardMgmt.WebApi/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost\\SQLEXPRESS;Database=BoardMgmtDb;User=sa;Password=Admin@123;Trusted_Connection=True;TrustServerCertificate=True;"
+    "DefaultConnection": "Server=localhost\\SQLEXPRESS;Database=BoardMgmtDb;User Id=sa;Password=Admin@123;Trusted_Connection=False;TrustServerCertificate=True;MultipleActiveResultSets=True"
   },
   "Jwt": {
     "Issuer": "BoardMgmt",
@@ -30,7 +30,7 @@
       {
         "Name": "MSSqlServer",
         "Args": {
-          "connectionString": "Server=localhost\\SQLEXPRESS;Database=BoardMgmtDb;User Id=sa;Password=Admin@123;TrustServerCertificate=True;",
+          "connectionString": "Server=localhost\\SQLEXPRESS;Database=BoardMgmtDb;User Id=sa;Password=Admin@123;Trusted_Connection=False;TrustServerCertificate=True;MultipleActiveResultSets=True",
           "tableName": "Logs",
           "schemaName": "dbo",
           "autoCreateSqlTable": true, // 👈 auto-create the table


### PR DESCRIPTION
## Summary
- update the default SQL Server connection string to disable trusted authentication when SQL credentials are provided
- ensure the fallback connection string used at runtime and for design-time tooling matches the SQL authentication settings
- keep the Serilog sink aligned with the updated connection string

## Testing
- not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f32a6498a48320a2acd14bdada2b82