### PR TITLE
Extend ignore rules for Graph and Zoom configuration secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,11 @@ appsettings.Development.json
 appsettings.Graph.json
 appsettings.Zoom.json
 appsettings.Local.json
+# Explicitly ignore WebApi-local copies that may include secrets
+src/BoardMgmt.WebApi/appsettings.Development.json
+src/BoardMgmt.WebApi/appsettings.Graph.json
+src/BoardMgmt.WebApi/appsettings.Zoom.json
+src/BoardMgmt.WebApi/appsettings.Local.json
 
 # Local secrets or token caches
 GraphTokens.json


### PR DESCRIPTION
## Summary
- expand the Graph/Zoom section of the root `.gitignore` to cover WebApi-specific appsettings files that may contain credentials

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f32e5bbf748320a7f936d8020eef33