### PR TITLE
Add SQLite fallback for development

### DIFF
--- a/src/BoardMgmt.Infrastructure/BoardMgmt.Infrastructure.csproj
+++ b/src/BoardMgmt.Infrastructure/BoardMgmt.Infrastructure.csproj
@@ -12,6 +12,7 @@
                 <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
                 <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.8" />
                 <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BoardMgmt.Infrastructure/Persistence/AppDbContextFactory.cs
+++ b/src/BoardMgmt.Infrastructure/Persistence/AppDbContextFactory.cs
@@ -24,14 +24,28 @@ public sealed class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbConte
             .Build();
 
         var cs = config.GetConnectionString("DefaultConnection");
+        var useSqlite = false;
+
         if (string.IsNullOrWhiteSpace(cs))
         {
-            cs = "Server=(localdb)\\MSSQLLocalDB;Database=BoardMgmtDb;Trusted_Connection=True;MultipleActiveResultSets=True";
+            var dataDirectory = Path.Combine(basePath, "App_Data");
+            Directory.CreateDirectory(dataDirectory);
+            cs = $"Data Source={Path.Combine(dataDirectory, "boardmgmt.db")}";
+            useSqlite = true;
         }
 
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseSqlServer(cs)
-            .Options;
+        var builder = new DbContextOptionsBuilder<AppDbContext>();
+
+        if (useSqlite)
+        {
+            builder.UseSqlite(cs);
+        }
+        else
+        {
+            builder.UseSqlServer(cs);
+        }
+
+        var options = builder.Options;
 
         return new AppDbContext(options);
     }


### PR DESCRIPTION
## Summary
- add Microsoft.Data.Sqlite provider to the infrastructure project
- fall back to a SQLite database file when no SQL Server connection string is configured
- align the EF Core design-time factory with the new SQLite fallback

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f3459dbdac8320af9864e90f6e2f9d