### PR TITLE
Add SQLite fallback for LocalDB connection strings

### DIFF
--- a/src/BoardMgmt.Infrastructure/Persistence/AppDbContextFactory.cs
+++ b/src/BoardMgmt.Infrastructure/Persistence/AppDbContextFactory.cs
@@ -23,16 +23,9 @@ public sealed class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbConte
             .AddEnvironmentVariables()
             .Build();
 
-        var cs = config.GetConnectionString("DefaultConnection");
-        var useSqlite = false;
-
-        if (string.IsNullOrWhiteSpace(cs))
-        {
-            var dataDirectory = Path.Combine(basePath, "App_Data");
-            Directory.CreateDirectory(dataDirectory);
-            cs = $"Data Source={Path.Combine(dataDirectory, "boardmgmt.db")}";
-            useSqlite = true;
-        }
+        var (cs, useSqlite) = ConnectionStringHelper.Resolve(
+            config.GetConnectionString("DefaultConnection"),
+            basePath);
 
         var builder = new DbContextOptionsBuilder<AppDbContext>();
 

--- a/src/BoardMgmt.Infrastructure/Persistence/ConnectionStringHelper.cs
+++ b/src/BoardMgmt.Infrastructure/Persistence/ConnectionStringHelper.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+
+namespace BoardMgmt.Infrastructure.Persistence;
+
+internal static class ConnectionStringHelper
+{
+    private const string SqliteFileName = "boardmgmt.db";
+
+    public static (string ConnectionString, bool UseSqlite) Resolve(string? configuredConnectionString, string baseDirectory)
+    {
+        if (ShouldUseSqlite(configuredConnectionString))
+        {
+            var dataDirectory = Path.Combine(baseDirectory, "App_Data");
+            Directory.CreateDirectory(dataDirectory);
+            var sqlitePath = Path.Combine(dataDirectory, SqliteFileName);
+            return ($"Data Source={sqlitePath}", true);
+        }
+
+        return (configuredConnectionString!, false);
+    }
+
+    private static bool ShouldUseSqlite(string? connectionString)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return true;
+        }
+
+        return connectionString.Contains("(localdb)", StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared helper that resolves the configured database connection string and falls back to a local SQLite file when necessary
- ensure both runtime dependency injection and the design-time AppDbContextFactory use the helper so LocalDB connection strings no longer trigger SQL Server lookups on non-Windows hosts

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f346bf8b8883209da26180dd6f1ad2